### PR TITLE
Failing test for 404 which becomes 406

### DIFF
--- a/src/modules/jcms_rest/src/Routing/JcmsRestResourceRouteFilter.php
+++ b/src/modules/jcms_rest/src/Routing/JcmsRestResourceRouteFilter.php
@@ -49,6 +49,13 @@ class JcmsRestResourceRouteFilter implements RouteFilterInterface {
       $path = $request->getPathInfo();
       $accept_header = $request->headers->get('Accept');
       $acceptable_mime_type = $this->pathMimeTypeMapper->getMimeTypeByPath($path);
+      /*
+      error_log("new HTTP request");
+      error_log($path);
+      error_log($accept_header);
+      $e = new \Exception();
+      error_log($e->getTraceAsString());
+      */
       if (AcceptHeader::fromString($accept_header)->get($acceptable_mime_type)) {
         $collection->add($name, $route);
       }

--- a/src/modules/jcms_rest/tests/src/EndpointValidatorTest.php
+++ b/src/modules/jcms_rest/tests/src/EndpointValidatorTest.php
@@ -94,4 +94,12 @@ class EndpointValidatorTest extends UnitTestCase {
     $messageValidator->validate($response);
   }
 
+  public function testNotExistent() {
+    $request = new Request('GET', '/subjects/does-not-exist', [
+      'Accept' => 'application/vnd.elife.subject+json; version=1',
+    ]);
+    $response = $this->client->send($request);
+    $this->assertEquals(404, $response->getStatusCode());
+  }
+
 }


### PR DESCRIPTION
See
http://jira.elifesciences.org:8080/browse/ELPP-1209?focusedCommentId=14753&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-14753

There is some commented out code that shows the code passing again from
filter() while trying to render an error page. Pay attention that if you
fix this once, the test will start passing again even if the code
changes because the rendering of the page is cached; I had to run `drush
cache:clear` to make the test red again.