### PR TITLE
Add test to API calls to the item endpoints by hitting all items return in a list query

### DIFF
--- a/src/modules/jcms_rest/src/Plugin/rest/resource/AbstractRestResourceBase.php
+++ b/src/modules/jcms_rest/src/Plugin/rest/resource/AbstractRestResourceBase.php
@@ -127,7 +127,7 @@ abstract class AbstractRestResourceBase extends ResourceBase {
             break;
           case 'image':
             $image = $content_item->get('field_block_image')->first();
-            $result_item['alt'] = $image->getValue()['alt'];
+            $result_item['alt'] = (string) $image->getValue()['alt'];
             $result_item['uri'] = file_create_url($image->get('entity')->getTarget()->get('uri')->first()->getValue()['value']);
             if ($content_item->get('field_block_html')->count()) {
               $result_item['title'] = $content_item->get('field_block_html')->first()->getValue()['value'];
@@ -145,7 +145,7 @@ abstract class AbstractRestResourceBase extends ResourceBase {
             $result_item['height'] = (int) $content_item->get('field_block_youtube_height')->first()->getValue()['value'];
             break;
           case 'table':
-            $result_item['tables'] = [$content_item->get('field_block_html')->first()->getValue()['value']];
+            $result_item['tables'] = [preg_replace('/\n/', '', $content_item->get('field_block_html')->first()->getValue()['value'])];
             break;
           case 'list':
             $result_item['ordered'] = $content_item->get('field_block_list_ordered')->first()->getValue()['value'] ? TRUE : FALSE;
@@ -153,9 +153,14 @@ abstract class AbstractRestResourceBase extends ResourceBase {
             break;
           case 'list_item':
             $result_item = $content_item->get('field_block_html')->first()->getValue()['value'];
+            break;
+          default:
+            unset($result_item['type']);
         }
 
-        $result[] = $result_item;
+        if (!empty($result_item)) {
+          $result[] = $result_item;
+        }
       }
 
       return $result;

--- a/src/modules/jcms_rest/tests/src/RecursiveEndpointValidatorTest.php
+++ b/src/modules/jcms_rest/tests/src/RecursiveEndpointValidatorTest.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace Drupal\Tests\jcms_rest\Unit;
+
+use Drupal\Tests\UnitTestCase;
+use eLife\ApiValidator\MessageValidator\FakeHttpsMessageValidator;
+use GuzzleHttp\Client;
+use GuzzleHttp\Psr7\Request;
+use eLife\ApiValidator\MessageValidator\JsonMessageValidator;
+use eLife\ApiValidator\SchemaFinder\PuliSchemaFinder;
+use Webmozart\Json\JsonDecoder;
+use \Puli\GeneratedPuliFactory;
+
+/**
+ * Test to interrogate all items in a query to a list API endpoint.
+ *
+ * This is useful to verify that the migration of content has been successful.
+ *
+ * @package Drupal\Tests\jcms_rest\Unit
+ */
+class RecursiveEndpointValidatorTest extends UnitTestCase {
+
+  private $projectRoot;
+
+  private $client;
+
+  private $resourceRepository;
+
+  public function setUp() {
+    // Using Puli CLI as a Composer dependency means the class
+    // "Puli\GeneratedPuliFactory" is not found by the autoloader. In this case,
+    // we load it in manually.
+    $this->projectRoot = realpath(__DIR__ . '/../../../../..');
+    if (!class_exists('Puli\GeneratedPuliFactory')) {
+      if (file_exists($this->projectRoot . '/.puli/GeneratedPuliFactory.php')) {
+        require_once($this->projectRoot . '/.puli/GeneratedPuliFactory.php');
+      }
+    }
+    // Setup Puli.
+    $this->resourceRepository = (new GeneratedPuliFactory)->createRepository();
+    $this->client = new Client([
+      'base_uri' => 'http://journal-cms.local/',
+      'http_errors' => FALSE,
+    ]);
+  }
+
+  /**
+   * Data provider for the validator test.
+   *
+   * @return array
+   */
+  public function dataProvider() : array {
+    return [
+      [
+        '/subjects',
+        'id',
+        'application/vnd.elife.subject-list+json;version=1',
+        'application/vnd.elife.subject+json;version=1',
+      ],
+      [
+        '/blog-articles',
+        'id',
+        'application/vnd.elife.blog-article-list+json;version=1',
+        'application/vnd.elife.blog-article+json;version=1',
+      ],
+      [
+        '/labs-experiments',
+        'number',
+        'application/vnd.elife.labs-experiment-list+json;version=1',
+        'application/vnd.elife.labs-experiment+json;version=1',
+      ],
+    ];
+  }
+
+  /**
+   * @test
+   * @dataProvider dataProvider
+   * @param string $endpoint
+   * @param string $id_key
+   * @param string $mime_type_list
+   * @param string $mime_type_item
+   */
+  public function testValidEndpointsRecursively(string $endpoint, string $id_key, string $mime_type_list, string $mime_type_item) {
+    $request = new Request('GET', $endpoint . '?per-page=1', [
+      'Accept' => $mime_type_list,
+    ]);
+
+    $response = $this->client->send($request);
+    $data = \GuzzleHttp\json_decode($response->getBody()->getContents());
+    $total = $data->total;
+
+    $request = new Request('GET', $endpoint . '?per-page=' . $total, [
+      'Accept' => $mime_type_list,
+    ]);
+
+    $response = $this->client->send($request);
+    $data = \GuzzleHttp\json_decode($response->getBody()->getContents());
+    $json_decoder = new JsonDecoder();
+    $messageValidator = new FakeHttpsMessageValidator(new JsonMessageValidator(new PuliSchemaFinder($this->resourceRepository), $json_decoder), $json_decoder);
+    $messageValidator->validate($response);
+
+    foreach ($data->items as $item) {
+      $request = new Request('GET', $endpoint . '/' . $item->{$id_key}, [
+        'Accept' => $mime_type_item
+      ]);
+
+      $response = $this->client->send($request);
+      $json_decoder = new JsonDecoder();
+      $messageValidator = new FakeHttpsMessageValidator(new JsonMessageValidator(new PuliSchemaFinder($this->resourceRepository), $json_decoder), $json_decoder);
+      $messageValidator->validate($response);
+    }
+  }
+
+}


### PR DESCRIPTION
This is useful for verifying that migration of content from the legacy database has been successful and for surfacing bugs in the code.