### PR TITLE
Consistently referring to JcmsNotAcceptableHttpException

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ before_install:
   - sh $TRAVIS_BUILD_DIR/scripts/travis/mysql-reset-root-password.sh
   - curl https://puli.io/installer | php
   - echo 'sendmail_path = /bin/true' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
+  - echo 'xdebug.max_nesting_level = 512' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
   - composer --verbose self-update
 
 install:

--- a/src/modules/jcms_rest/src/Exception/JcmsNotAcceptableHttpException.php
+++ b/src/modules/jcms_rest/src/Exception/JcmsNotAcceptableHttpException.php
@@ -6,14 +6,12 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 
 /**
- * Class JCMSNotAcceptableHttpException
- *
  * This should be used instead of the Symfony NotAcceptableHttpException as we
  * need to set the content type header.
  *
  * @package Drupal\jcms_rest\Exception
  */
-class JCMSNotAcceptableHttpException extends HttpException {
+class JcmsNotAcceptableHttpException extends HttpException {
 
   public function __construct($message, \Exception $previous = NULL, $media_type, $code = 0) {
     parent::__construct(Response::HTTP_NOT_ACCEPTABLE, $message, $previous, ['Content-Type' => $media_type], $code);

--- a/src/modules/jcms_rest/src/Exception/JcmsNotFoundHttpException.php
+++ b/src/modules/jcms_rest/src/Exception/JcmsNotFoundHttpException.php
@@ -6,14 +6,12 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 
 /**
- * Class JCMSNotAcceptableHttpException
- *
  * This should be used instead of the Symfony NotFoundHttpException as we
  * need to set the content type header.
  *
  * @package Drupal\jcms_rest\Exception
  */
-class JCMSNotFoundHttpException extends HttpException {
+class JcmsNotFoundHttpException extends HttpException {
 
   public function __construct($message, \Exception $previous = NULL, $media_type, $code = 0) {
     parent::__construct(Response::HTTP_NOT_FOUND, $message, $previous, ['Content-Type' => $media_type], $code);

--- a/src/modules/jcms_rest/src/Routing/JcmsRestResourceRouteFilter.php
+++ b/src/modules/jcms_rest/src/Routing/JcmsRestResourceRouteFilter.php
@@ -3,7 +3,7 @@
 namespace Drupal\jcms_rest\Routing;
 
 use Drupal\Core\Routing\RouteFilterInterface;
-use Drupal\jcms_rest\Exception\JCMSNotAcceptableHttpException;
+use Drupal\jcms_rest\Exception\JcmsNotAcceptableHttpException;
 use Drupal\jcms_rest\PathMediaTypeMapper;
 use Symfony\Component\HttpFoundation\AcceptHeader;
 use Symfony\Component\HttpFoundation\Request;
@@ -63,7 +63,7 @@ class JcmsRestResourceRouteFilter implements RouteFilterInterface {
     // We do not throw a
     // \Symfony\Component\Routing\Exception\ResourceNotFoundException here
     // because we don't want to return a 404 status code, but rather a 406.
-    throw new JCMSNotAcceptableHttpException("No route found for the specified accept header $accept_header.", NULL, $acceptable_media_type);
+    throw new JcmsNotAcceptableHttpException("No route found for the specified accept header $accept_header.", NULL, $acceptable_media_type);
   }
 
 }


### PR DESCRIPTION
Was referred to as `JCMSNotAcceptableHttpException` which is probably causing a class not found error on Ubuntu servers when `Accept` headers are incorrect.