### PR TITLE
Source and migrate the about sections of press packages

### DIFF
--- a/src/modules/jcms_migrate/config/install/migrate_plus.migration.people_db.yml
+++ b/src/modules/jcms_migrate/config/install/migrate_plus.migration.people_db.yml
@@ -32,7 +32,8 @@ process:
     -
       plugin: jcms_split_paragraphs
       source: profile_description
-      strip_keywords: true
+      strip_regex: "(keywords|major subject area)"
+      break_regex: true
     -
       plugin: jcms_content
       multiple: true

--- a/src/modules/jcms_migrate/config/install/migrate_plus.migration.press_packages_db.yml
+++ b/src/modules/jcms_migrate/config/install/migrate_plus.migration.press_packages_db.yml
@@ -47,6 +47,17 @@ process:
     -
       plugin: jcms_media_contact
       multiple: true
+  field_press_package_about:
+    -
+      plugin: jcms_press_package_content
+      source: content
+      section: about
+    -
+      plugin: jcms_split_paragraphs
+      strip_regex: ".*elife.*"
+    -
+      plugin: jcms_content
+      multiple: true
 
 migration_dependencies:
   required:

--- a/src/modules/jcms_migrate/src/Plugin/migrate/process/JCMSSplitParagraphs.php
+++ b/src/modules/jcms_migrate/src/Plugin/migrate/process/JCMSSplitParagraphs.php
@@ -39,9 +39,14 @@ class JCMSSplitParagraphs extends ProcessPluginBase {
         }
         $innerHTML = trim($this->checkMarkup($innerHTML, 'basic_html'));
         if (!empty($innerHTML)) {
-          if (isset($this->configuration['strip_keywords']) && $this->configuration['strip_keywords'] === TRUE) {
-            if (preg_match('/(keywords|major subject area)/i', $innerHTML)) {
-              break;
+          if (!empty($this->configuration['strip_regex'])) {
+            if (preg_match('/' . $this->configuration['strip_regex'] . '/i', $innerHTML)) {
+              if (isset($this->configuration['break_regex']) && $this->configuration['break_regex'] === TRUE) {
+                break;
+              }
+              else {
+                continue;
+              }
             }
           }
           $paragraphs[] = [

--- a/sync/core.entity_form_display.node.press_package.default.yml
+++ b/sync/core.entity_form_display.node.press_package.default.yml
@@ -6,6 +6,7 @@ dependencies:
     - field.field.node.press_package.field_content
     - field.field.node.press_package.field_impact_statement
     - field.field.node.press_package.field_media_contact
+    - field.field.node.press_package.field_press_package_about
     - field.field.node.press_package.field_related_content
     - node.type.press_package
   module:
@@ -40,6 +41,16 @@ content:
     settings:
       title: 'Media contact'
       title_plural: 'Media contacts'
+      edit_mode: open
+      add_mode: dropdown
+      form_display_mode: default
+    third_party_settings: {  }
+  field_press_package_about:
+    type: entity_reference_paragraphs
+    weight: 30
+    settings:
+      title: Paragraph
+      title_plural: Paragraphs
       edit_mode: open
       add_mode: dropdown
       form_display_mode: default

--- a/sync/core.entity_view_display.node.press_package.default.yml
+++ b/sync/core.entity_view_display.node.press_package.default.yml
@@ -6,6 +6,7 @@ dependencies:
     - field.field.node.press_package.field_content
     - field.field.node.press_package.field_impact_statement
     - field.field.node.press_package.field_media_contact
+    - field.field.node.press_package.field_press_package_about
     - field.field.node.press_package.field_related_content
     - node.type.press_package
   module:
@@ -34,6 +35,14 @@ content:
   field_media_contact:
     type: entity_reference_revisions_entity_view
     weight: 104
+    label: above
+    settings:
+      view_mode: default
+      link: ''
+    third_party_settings: {  }
+  field_press_package_about:
+    type: entity_reference_revisions_entity_view
+    weight: 105
     label: above
     settings:
       view_mode: default

--- a/sync/field.field.node.press_package.field_press_package_about.yml
+++ b/sync/field.field.node.press_package.field_press_package_about.yml
@@ -1,0 +1,72 @@
+uuid: cf2dbc79-8c26-41e3-a622-1713f7d6b521
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_press_package_about
+    - node.type.press_package
+    - paragraphs.paragraphs_type.paragraph
+  module:
+    - entity_reference_revisions
+id: node.press_package.field_press_package_about
+field_name: field_press_package_about
+entity_type: node
+bundle: press_package
+label: About
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:paragraph'
+  handler_settings:
+    target_bundles:
+      paragraph: paragraph
+    target_bundles_drag_drop:
+      blockquote:
+        weight: 16
+        enabled: false
+      cv_item:
+        weight: 17
+        enabled: false
+      episode_chapter:
+        weight: 18
+        enabled: false
+      image:
+        weight: 19
+        enabled: false
+      json:
+        weight: 20
+        enabled: false
+      list:
+        weight: 21
+        enabled: false
+      list_item:
+        weight: 22
+        enabled: false
+      media_contact:
+        weight: 23
+        enabled: false
+      paragraph:
+        enabled: true
+        weight: 24
+      question:
+        weight: 25
+        enabled: false
+      research_details:
+        weight: 26
+        enabled: false
+      section:
+        weight: 27
+        enabled: false
+      table:
+        weight: 28
+        enabled: false
+      venue:
+        weight: 29
+        enabled: false
+      youtube:
+        weight: 30
+        enabled: false
+field_type: entity_reference_revisions

--- a/sync/field.storage.node.field_press_package_about.yml
+++ b/sync/field.storage.node.field_press_package_about.yml
@@ -1,0 +1,25 @@
+uuid: d05075bf-17b9-48f1-ae0d-5ed905181ffc
+langcode: en
+status: true
+dependencies:
+  module:
+    - entity_reference_revisions
+    - field_permissions
+    - node
+    - paragraphs
+third_party_settings:
+  field_permissions:
+    permission_type: public
+id: node.field_press_package_about
+field_name: field_press_package_about
+entity_type: node
+type: entity_reference_revisions
+settings:
+  target_type: paragraph
+module: entity_reference_revisions
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/sync/migrate_plus.migration.jcms_annual_reports_json.yml
+++ b/sync/migrate_plus.migration.jcms_annual_reports_json.yml
@@ -1,4 +1,4 @@
-uuid: f38b287a-5bfa-411b-98b4-4bd982a76a2a
+uuid: 560fed19-1c94-4c9c-aa8d-a1d771606595
 langcode: en
 status: true
 dependencies: {  }

--- a/sync/migrate_plus.migration.jcms_blog_articles_db.yml
+++ b/sync/migrate_plus.migration.jcms_blog_articles_db.yml
@@ -1,4 +1,4 @@
-uuid: b4dd2f6a-b229-4dfd-8dde-90fc46dbe56d
+uuid: 1f6d3237-4463-474e-922e-20602b84a318
 langcode: en
 status: true
 dependencies: {  }

--- a/sync/migrate_plus.migration.jcms_collections_db.yml
+++ b/sync/migrate_plus.migration.jcms_collections_db.yml
@@ -1,4 +1,4 @@
-uuid: f81272db-4676-42a4-b34f-7c6dfd9745de
+uuid: fc2f87d7-ed50-4601-86d8-ac9ddb57da84
 langcode: en
 status: true
 dependencies: {  }

--- a/sync/migrate_plus.migration.jcms_collections_json.yml
+++ b/sync/migrate_plus.migration.jcms_collections_json.yml
@@ -1,4 +1,4 @@
-uuid: a69cac1c-1b22-4c29-aa7b-4733cf5de23e
+uuid: 57e85601-3bb1-4b08-be61-aa856ca69418
 langcode: en
 status: true
 dependencies: {  }

--- a/sync/migrate_plus.migration.jcms_interviews_db.yml
+++ b/sync/migrate_plus.migration.jcms_interviews_db.yml
@@ -1,4 +1,4 @@
-uuid: 2e6f7833-ede3-4df5-8c24-f486767ba1fc
+uuid: bf79c0f9-135c-4943-81b0-8804aa45d09b
 langcode: en
 status: true
 dependencies: {  }

--- a/sync/migrate_plus.migration.jcms_labs_experiments_json.yml
+++ b/sync/migrate_plus.migration.jcms_labs_experiments_json.yml
@@ -1,4 +1,4 @@
-uuid: 845cdd95-0268-4a46-87f2-93f24ee8ebe0
+uuid: 9302562b-f572-448b-a309-a6dc103fd3c2
 langcode: en
 status: true
 dependencies: {  }

--- a/sync/migrate_plus.migration.jcms_people_db.yml
+++ b/sync/migrate_plus.migration.jcms_people_db.yml
@@ -1,9 +1,9 @@
-uuid: c43539a9-5d33-499e-9183-78b41ec83a25
+uuid: 4a2a7b3a-0f09-4afe-9eef-3640a4661f79
 langcode: en
 status: true
 dependencies: {  }
 _core:
-  default_config_hash: lmvQ9jYjklIWO0FDe0NBCIm1MtLA1QG2cnEsXWK6Hgw
+  default_config_hash: jUkI4j8eAF8mM0RLlbdF8g8beyiVf8j3IchD72Iz2LU
 id: jcms_people_db
 class: null
 migration_tags: null
@@ -37,7 +37,8 @@ process:
     -
       plugin: jcms_split_paragraphs
       source: profile_description
-      strip_keywords: true
+      strip_regex: '(keywords|major subject area)'
+      break_regex: true
     -
       plugin: jcms_content
       multiple: true

--- a/sync/migrate_plus.migration.jcms_podcast_episodes_json.yml
+++ b/sync/migrate_plus.migration.jcms_podcast_episodes_json.yml
@@ -1,4 +1,4 @@
-uuid: 9ff40426-cc6b-4f21-a9e3-c783b2cbb7a7
+uuid: f4bc2991-5593-4d83-acf8-5cdbafad3a29
 langcode: en
 status: true
 dependencies: {  }

--- a/sync/migrate_plus.migration.jcms_press_packages_db.yml
+++ b/sync/migrate_plus.migration.jcms_press_packages_db.yml
@@ -1,9 +1,9 @@
-uuid: c17ba37b-69d7-430a-9cff-53175fdec657
+uuid: 4c5b6f6e-6225-4105-a0ae-81a842cd23e2
 langcode: en
 status: true
 dependencies: {  }
 _core:
-  default_config_hash: Ak98z85FX2vq-FY-6A5oOs1t4P9aGmYDV3isX2tJ_nc
+  default_config_hash: T1DeCZcUvGm0vHTmIZQfCxVJZz1GIVpd_cknbO8gx9U
 id: jcms_press_packages_db
 class: null
 migration_tags: null
@@ -51,6 +51,17 @@ process:
       section: mediaContacts
     -
       plugin: jcms_media_contact
+      multiple: true
+  field_press_package_about:
+    -
+      plugin: jcms_press_package_content
+      source: content
+      section: about
+    -
+      plugin: jcms_split_paragraphs
+      strip_regex: '*elife.*'
+    -
+      plugin: jcms_content
       multiple: true
 destination:
   plugin: 'entity:node'

--- a/sync/migrate_plus.migration.jcms_research_focuses_json.yml
+++ b/sync/migrate_plus.migration.jcms_research_focuses_json.yml
@@ -1,4 +1,4 @@
-uuid: 9c7f9bcd-7d14-4414-820d-8c3c7fd22ee4
+uuid: 9df49ec1-09a1-4d86-be96-3a471bdcbbc5
 langcode: en
 status: true
 dependencies: {  }

--- a/sync/migrate_plus.migration.jcms_research_organisms_json.yml
+++ b/sync/migrate_plus.migration.jcms_research_organisms_json.yml
@@ -1,4 +1,4 @@
-uuid: 1ca7c866-41c8-47e2-85af-f2c3e061b5f0
+uuid: 5cf01f33-7ba4-4892-ba17-6d31918de3dc
 langcode: en
 status: true
 dependencies: {  }

--- a/sync/migrate_plus.migration.jcms_subjects_json.yml
+++ b/sync/migrate_plus.migration.jcms_subjects_json.yml
@@ -1,4 +1,4 @@
-uuid: 47a1dbf6-36b4-45d5-a256-a719a4fb458f
+uuid: b6579330-f8f2-442e-80f0-8971fd4118e2
 langcode: en
 status: true
 dependencies: {  }

--- a/sync/migrate_plus.migration_group.jcms_migrate.yml
+++ b/sync/migrate_plus.migration_group.jcms_migrate.yml
@@ -1,4 +1,4 @@
-uuid: cdec7ba5-bf62-465c-afdf-5d80c1fa7c88
+uuid: 03a47da5-7dfb-475e-a800-fd0f80367132
 langcode: en
 status: true
 dependencies: {  }


### PR DESCRIPTION
After the json schema has been amended then we can follow up with the work to introduce the about sections into the press-packages API response.

See: https://github.com/elifesciences/api-raml/pull/107