### PR TITLE
Increase max length of block title from 255 to 510

### DIFF
--- a/sync/field.storage.paragraph.field_block_title.yml
+++ b/sync/field.storage.paragraph.field_block_title.yml
@@ -13,7 +13,7 @@ field_name: field_block_title
 entity_type: paragraph
 type: string
 settings:
-  max_length: 255
+  max_length: 510
   is_ascii: false
   case_sensitive: false
 module: core


### PR DESCRIPTION
Increasing length of block title field as there is a question that exceeds 255 characters