### PR TITLE
ELPP-2107 Removed dblog module from module configuration.

### DIFF
--- a/sync/core.extension.yml
+++ b/sync/core.extension.yml
@@ -17,7 +17,6 @@ module:
   ctools: 0
   datetime: 0
   datetime_range: 0
-  dblog: 0
   devel_generate: 0
   dynamic_page_cache: 0
   editor: 0

--- a/sync/dblog.settings.yml
+++ b/sync/dblog.settings.yml
@@ -1,3 +1,0 @@
-row_limit: 1000
-_core:
-  default_config_hash: e883aGsrt1wFrsydlYU584PZONCSfRy0DtkZ9KzHb58


### PR DESCRIPTION
@giorgiosironi As discussed.

@nlisgo Below is a list of additional modules I think we should disable. Some are used in development but they should be disabled in production so we can enable them at the time they're needed. The performance gains would be marginal but it also keeps the install clean and small.

- automated_cron
- color
- comment
- contact
- field_ui
- hal
- history
- rdf
- search
- tour
- views_ui