### PR TITLE
Optimizing external calls on article-import-all

### DIFF
--- a/src/modules/jcms_article/jcms_article.module
+++ b/src/modules/jcms_article/jcms_article.module
@@ -32,8 +32,9 @@ function jcms_article_node_presave(EntityInterface $entity) {
     return NULL;
   }
   $node_presave = \Drupal::service('jcms_article.hooks.node_presave');
-  $node_presave->addJsonFields($entity);
-  $node_presave->setPublishedStatus($entity);
-  $node_presave->setStatusDate($entity);
-  $node_presave->setSubjectTerms($entity);
+  $article = $node_presave->getArticleById($entity->label());
+  $node_presave->addJsonFields($entity, $article);
+  $node_presave->setPublishedStatus($entity, $article);
+  $node_presave->setStatusDate($entity, $article);
+  $node_presave->setSubjectTerms($entity, $article);
 }


### PR DESCRIPTION
Before the change, the static cache was not working very well as each article being imported was causing 5 requests to the /articles/:id/version API. After the change, the number of calls is reduced to 2, one in the service and only one from the NodePresave object.

Moreover, passing the article object on the stack is safer than keeping it around as a global static field, which may distribute stale data in long-running processes