### PR TITLE
Log type and id of content items just notified

### DIFF
--- a/src/modules/jcms_notifications/drush/jcms_notifications.drush.inc
+++ b/src/modules/jcms_notifications/drush/jcms_notifications.drush.inc
@@ -159,8 +159,8 @@ function drush_jcms_notifications_send_notifications() {
     $nids = [];
     foreach ($nodes as $node) {
       $nids[] = $node->id();
-      $sns_crud->sendMessage($node);
-      drush_print(dt('Sent notification for !type !id (nid: !nid)', ['!type' => $node->getType(), '!id' => '?', '!nid' => $node->id()]));
+      $busMessage = $sns_crud->sendMessage($node);
+      drush_print(dt('Sent notification !message (nid: !nid)', ['!message' => $busMessage->getMessageJson(), '!nid' => $node->id()]));
     }
     $storage->deleteNotificationNids($nids);
     sleep($sleep);

--- a/src/modules/jcms_notifications/drush/jcms_notifications.drush.inc
+++ b/src/modules/jcms_notifications/drush/jcms_notifications.drush.inc
@@ -160,7 +160,7 @@ function drush_jcms_notifications_send_notifications() {
     foreach ($nodes as $node) {
       $nids[] = $node->id();
       $sns_crud->sendMessage($node);
-      drush_print(dt('Sent notification for !nid', ['!nid' => $node->id()]));
+      drush_print(dt('Sent notification for !type !id (nid: !nid)', ['!type' => $node->getType(), '!id' => '?', '!nid' => $node->id()]));
     }
     $storage->deleteNotificationNids($nids);
     sleep($sleep);


### PR DESCRIPTION
@jamiehollern how do we make it log the actual id sent in the notifications (e.g. `ba88c0df`)?