### PR TITLE
Undefined method while sending notifications

### DIFF
--- a/src/modules/jcms_notifications/drush/jcms_notifications.drush.inc
+++ b/src/modules/jcms_notifications/drush/jcms_notifications.drush.inc
@@ -172,7 +172,7 @@ function drush_jcms_notifications_send_notifications() {
       $busMessage = $sns_crud->sendMessage($entity);
       drush_print(dt('[!date] Sent notification !message (entity id: !eid)', ['!date' => date('c'), '!message' => $busMessage->getMessageJson(), '!eid' => $entity->id()]));
     }
-    $storage->deleteNotificationIds($entity_ids);
+    $storage->deleteNotificationEntityIds($entity_ids);
     sleep($sleep);
   }
   drush_print(dt('Exiting because of limits reached.'));


### PR DESCRIPTION
After a batch of notifications is sent, the send-notifications long-running process crashes and restarts from the beginning.

Problem comes from https://github.com/elifesciences/journal-cms/pull/121