### PR TITLE
Add the whole url as cacheable dependency

### DIFF
--- a/src/modules/jcms_rest/src/Response/JCMSRestResponse.php
+++ b/src/modules/jcms_rest/src/Response/JCMSRestResponse.php
@@ -38,7 +38,7 @@ class JCMSRestResponse extends JsonResponse implements CacheableResponseInterfac
   public function addDefaultCacheableDependencies() {
     $build = [
       '#cache' => [
-        'contexts' => ['url.query_args'],
+        'contexts' => ['url', 'user.permissions'],
       ],
     ];
     $cache_metadata = CacheableMetadata::createFromRenderArray($build);


### PR DESCRIPTION
Hold off merging this into until journal-cms-formula PR: https://github.com/elifesciences/journal-cms-formula/pull/26

This PR addresses the issue of the hostname being incorrect for calls to the API.