### PR TITLE
Multiple UI improvements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     "drupal/field_collection": "~1.0-alpha1",
     "drupal/inline_entity_form": "~1.0-beta1",
     "drupal/jsonb": "~1.0-beta1",
-    "drupal/paragraphs": "~1.0",
+    "drupal/paragraphs": "1.x-dev",
     "drupal-composer/drupal-project": "8.x-dev",
     "drupal/migrate_plus": "~3.0-beta1",
     "drupal/migrate_tools": "^2.0",
@@ -83,10 +83,10 @@
     "drupal-scaffold": "DrupalComposer\\DrupalScaffold\\Plugin::scaffold",
     "post-install-cmd": [
       "DrupalComposer\\DrupalScaffold\\Plugin::scaffold",
-      "eLifeDrupalProject\\composer\\ScriptHandler::createRequiredFiles"
+      "JCMSDrupalProject\\composer\\ScriptHandler::createRequiredFiles"
     ],
     "post-update-cmd": [
-      "eLifeDrupalProject\\composer\\ScriptHandler::createRequiredFiles"
+      "JCMSDrupalProject\\composer\\ScriptHandler::createRequiredFiles"
     ]
   },
   "extra": {
@@ -125,6 +125,9 @@
       },
       "drupal/inline_entity_form": {
         "Field name/label disappears when I create a new entity inline": "https://www.drupal.org/files/issues/inline_entity_form-no_label_required_field_with_no_entries-2842744.patch"
+      },
+      "drupal/paragraphs": {
+        "Empty required fields not providing meaningful error messages": "https://www.drupal.org/files/issues/empty_required_fields-2788607-70.patch"
       }
     }
   }

--- a/composer.lock
+++ b/composer.lock
@@ -3103,20 +3103,14 @@
         },
         {
             "name": "drupal/paragraphs",
-            "version": "1.1.0",
+            "version": "dev-1.x",
             "source": {
                 "type": "git",
                 "url": "https://git.drupal.org/project/paragraphs",
-                "reference": "8.x-1.1"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/paragraphs-8.x-1.1.zip",
-                "reference": "8.x-1.1",
-                "shasum": "c678e5704a98c6a0549e415412da081cfeb03a00"
+                "reference": "ae21d1a63be7bd2f7d7319a7a7614510329c8a5e"
             },
             "require": {
-                "drupal/core": "~8.0",
+                "drupal/core": "*",
                 "drupal/entity_reference_revisions": "*"
             },
             "require-dev": {
@@ -3133,8 +3127,11 @@
                     "dev-1.x": "1.x-dev"
                 },
                 "drupal": {
-                    "version": "8.x-1.1",
-                    "datestamp": "1487331784"
+                    "version": "8.x-1.1+9-dev",
+                    "datestamp": "1489573684"
+                },
+                "patches_applied": {
+                    "Empty required fields not providing meaningful error messages": "https://www.drupal.org/files/issues/empty_required_fields-2788607-70.patch"
                 }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
@@ -3151,6 +3148,10 @@
                     "homepage": "https://www.drupal.org/user/514222"
                 },
                 {
+                    "name": "Primsi",
+                    "homepage": "https://www.drupal.org/user/282629"
+                },
+                {
                     "name": "jeroen.b",
                     "homepage": "https://www.drupal.org/user/1853532"
                 },
@@ -3163,7 +3164,8 @@
             "homepage": "https://www.drupal.org/project/paragraphs",
             "support": {
                 "source": "http://cgit.drupalcode.org/paragraphs"
-            }
+            },
+            "time": "2017-03-27 16:03:30"
         },
         {
             "name": "drupal/redis",
@@ -9635,6 +9637,7 @@
     "minimum-stability": "dev",
     "stability-flags": {
         "drupal/entity_reference_revisions": 20,
+        "drupal/paragraphs": 20,
         "drupal-composer/drupal-project": 20,
         "drupal/restui": 20,
         "drupal/address": 5,

--- a/config/config.yml
+++ b/config/config.yml
@@ -218,7 +218,7 @@ installed_extras:
   # - tideways
   # - upload-progress
   - varnish
-  # - xdebug
+  - xdebug
   # - xhprof
 
 # Add any extra apt or yum packages you would like installed.

--- a/scripts/composer/ScriptHandler.php
+++ b/scripts/composer/ScriptHandler.php
@@ -2,10 +2,10 @@
 
 /**
  * @file
- * Contains \eLifeDrupalProject\composer\ScriptHandler.
+ * Contains \JCMSDrupalProject\composer\ScriptHandler.
  */
 
-namespace eLifeDrupalProject\composer;
+namespace JCMSDrupalProject\composer;
 
 use Composer\Script\Event;
 use DrupalProject\composer\ScriptHandler as DrupalScriptHandler;

--- a/src/modules/jcms_admin/jcms_admin.module
+++ b/src/modules/jcms_admin/jcms_admin.module
@@ -4,9 +4,12 @@
  * JCMS admin module file.
  */
 
+use Drupal\Core\Database\Query\Condition;
+use Drupal\Core\Database\Query\SelectInterface;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Site\Settings;
 use Drupal\entityqueue\Entity\EntitySubqueue;
 use Drupal\node\Entity\Node;
 
@@ -138,7 +141,67 @@ function jcms_admin_form_entity_subqueue_covers_preview_edit_form_alter(&$form, 
     '#default_value' => FALSE,
     '#weight' => ++$max_weight,
   ];
-  array_unshift($form['actions']['submit']['#submit'], '_jcms_admin_form_entity_subqueue_covers_preview_edit_form_submit');
+  foreach (array_keys($form['actions']) as $action) {
+    if ($action != 'preview' && isset($form['actions'][$action]['#type']) && $form['actions'][$action]['#type'] === 'submit') {
+      array_unshift($form['actions'][$action]['#submit'], '_jcms_admin_form_entity_subqueue_covers_preview_edit_form_submit');
+    }
+  }
+}
+
+/**
+ * Implements hook_form_FORM_ID_alter().
+ */
+function jcms_admin_form_node_interview_form_alter(&$form, FormStateInterface $form_state) {
+  $max_weight = 0;
+  foreach ($form as $key => $value) {
+    $value = (array) $value;
+    if (!empty($value['#weight'])) {
+      $max_weight = max($max_weight, $value['#weight']);
+    }
+  }
+
+  $query = \Drupal::entityQuery('node')
+    ->condition('status', NODE_PUBLISHED)
+    ->condition('changed', REQUEST_TIME, '<')
+    ->condition('type', 'collection')
+    ->addTag('interview_collections_filter');
+  $collection_nids = $query->execute();
+
+  if ($collections = Node::loadMultiple($collection_nids)) {
+    $form['interview_collections'] = [
+      '#title' => t('Add to collection'),
+      '#type' => 'checkboxes',
+      '#default_value' => [],
+      '#options' => [],
+      '#weight' => ++$max_weight,
+    ];
+    foreach ($collections as $collection) {
+      $form['interview_collections']['#options'][$collection->id()] = $collection->label();
+    }
+    foreach (array_keys($form['actions']) as $action) {
+      if ($action != 'preview' && isset($form['actions'][$action]['#type']) && $form['actions'][$action]['#type'] === 'submit') {
+        array_unshift($form['actions'][$action]['#submit'], '_jcms_admin_form_node_interview_form_submit');
+      }
+    }
+  }
+}
+
+/**
+ * Implements hook_query_TAG_alter().
+ */
+function jcms_admin_query_interview_collections_filter_alter(SelectInterface $query) {
+  if ($whitelist = Settings::get('jcms_admin_interview_collections_whitelist')) {
+    $db_or = new Condition('OR');
+    foreach ($whitelist as $id) {
+      $db_or->condition('uuid', '%' . $id, 'LIKE');
+    }
+    $query->condition($db_or);
+  }
+  if ($blacklist = Settings::get('jcms_admin_interview_collections_blacklist')) {
+    foreach ($blacklist as $id) {
+      $query->condition('uuid', '%' . $id, 'NOT LIKE');
+    }
+  }
 }
 
 /**
@@ -197,18 +260,28 @@ function _jcms_admin_protect_id_field(&$form, $form_id) {
  * @param \Drupal\Core\Form\FormStateInterface $form_state
  */
 function _jcms_admin_form_entity_subqueue_covers_preview_edit_form_submit($form, FormStateInterface $form_state) {
-  _jcms_admin_covers_active('publish', $form_state->getValue('covers_active_publish', 0));
-  _jcms_admin_covers_active('reset', $form_state->getValue('covers_active_reset', 0));
+  _jcms_admin_static_store('covers_active_publish', $form_state->getValue('covers_active_publish', 0));
+  _jcms_admin_static_store('covers_active_reset', $form_state->getValue('covers_active_reset', 0));
 }
 
 /**
- * Store and retrieve values from form submission: entity_subqueue_covers_preview_edit_form.
+ * Submit function for node_interview_form.
+ *
+ * @param $form
+ * @param \Drupal\Core\Form\FormStateInterface $form_state
+ */
+function _jcms_admin_form_node_interview_form_submit($form, FormStateInterface $form_state) {
+  _jcms_admin_static_store('interview_collections', array_keys(array_filter($form_state->getValue('interview_collections', []))));
+}
+
+/**
+ * Store and retrieve values from form submission.
  *
  * @param string $key
  * @param mixed|NULL $value
  * @return mixed|NULL
  */
-function _jcms_admin_covers_active($key, $value = NULL) {
+function _jcms_admin_static_store($key, $value = NULL) {
   static $values = [];
   if (!is_null($value)) {
     $values[$key] = $value;
@@ -310,7 +383,7 @@ function jcms_admin_entity_subqueue_presave(EntityInterface $entity) {
   if ($entity->bundle() != 'covers_preview') {
     return NULL;
   }
-  if (_jcms_admin_covers_active('publish')) {
+  if (_jcms_admin_static_store('covers_active_publish')) {
     $items = ($entity->get('items')) ? $entity->get('items')->getValue() : [];
     $items = array_splice($items, 0, $entity->get('field_covers_active_items')->getString());
     foreach ($items as $item) {
@@ -336,7 +409,7 @@ function jcms_admin_entity_subqueue_presave(EntityInterface $entity) {
       ]));
     $subqueue->save();
   }
-  if (_jcms_admin_covers_active('reset')) {
+  if (_jcms_admin_static_store('covers_active_reset')) {
     $subqueue = EntitySubqueue::load('covers');
     $items = ($subqueue->get('items')) ? $subqueue->get('items')->getValue() : [];
     $entity->set('field_covers_active_items', 3);
@@ -370,6 +443,25 @@ function jcms_admin_node_delete(EntityInterface $entity) {
     // Delete orphaned highlight_item nodes.
     foreach ($entity->get('field_highlight_items')->referencedEntities() as $item) {
       $item->delete();
+    }
+  }
+}
+
+/**
+ * Implements hook_node_insert().
+ */
+function jcms_admin_node_insert(EntityInterface $entity) {
+  if ($entity->bundle() == 'interview') {
+    $collection_nids = _jcms_admin_static_store('interview_collections');
+    if (!empty($collection_nids) && $collections = Node::loadMultiple($collection_nids)) {
+      foreach ($collections as $collection) {
+        $content = $collection->get('field_collection_content')->getValue();
+        $content += [
+          'target_id' => $entity->id(),
+        ];
+        $collection->set('field_collection_content', $content);
+        $collection->save();
+      }
     }
   }
 }

--- a/src/modules/jcms_rest/src/Plugin/rest/resource/AbstractRestResourceBase.php
+++ b/src/modules/jcms_rest/src/Plugin/rest/resource/AbstractRestResourceBase.php
@@ -696,4 +696,18 @@ abstract class AbstractRestResourceBase extends ResourceBase {
     return \Drupal::currentUser()->hasPermission('view latest version');
   }
 
+  /**
+   * Process people names.
+   *
+   * @param string $preferred_name
+   * @param FieldItemListInterface $index_name
+   * @return array
+   */
+  public function processPeopleNames(string $preferred_name, FieldItemListInterface $index_name) {
+    return [
+      'preferred' => $preferred_name,
+      'index' => ($index_name->count()) ? $index_name->getString() : preg_replace('/^(?P<first_names>.*)\s+(?P<last_name>[^\s]+)$/', '$2, $1', $name['preferred']),
+    ];
+  }
+
 }

--- a/src/modules/jcms_rest/src/Plugin/rest/resource/InterviewItemRestResource.php
+++ b/src/modules/jcms_rest/src/Plugin/rest/resource/InterviewItemRestResource.php
@@ -44,10 +44,7 @@ class InterviewItemRestResource extends AbstractRestResourceBase {
 
       $response = $this->processDefault($node, $id);
 
-      $response['interviewee']['name'] = [
-        'preferred' => $node->get('field_person_preferred_name')->getString(),
-        'index' => $node->get('field_person_index_name')->getString(),
-      ];
+      $response['interviewee']['name'] = $this->processPeopleNames($node->get('field_person_preferred_name')->getString(), $node->get('field_person_index_name'));
 
       if ($node->get('field_interview_cv')->count()) {
         $response['interviewee']['cv'] = [];
@@ -55,7 +52,7 @@ class InterviewItemRestResource extends AbstractRestResourceBase {
           $cv_item = $paragraph->get('entity')->getTarget()->getValue();
           $response['interviewee']['cv'][] = [
             'date' => $cv_item->get('field_cv_item_date')->getString(),
-            'text' => $cv_item->get('field_block_html')->getString(),
+            'text' => $this->fieldValueFormatted($cv_item->get('field_block_html')),
           ];
         }
       }

--- a/src/modules/jcms_rest/src/Plugin/rest/resource/InterviewListRestResource.php
+++ b/src/modules/jcms_rest/src/Plugin/rest/resource/InterviewListRestResource.php
@@ -70,10 +70,7 @@ class InterviewListRestResource extends AbstractRestResourceBase {
     /* @var Node $node */
     $item = $this->processDefault($node);
 
-    $item['interviewee']['name'] = [
-      'preferred' => $node->get('field_person_preferred_name')->getString(),
-      'index' => $node->get('field_person_index_name')->getString(),
-    ];
+    $item['interviewee']['name'] = $this->processPeopleNames($node->get('field_person_preferred_name')->getString(), $node->get('field_person_index_name'));
 
     // Impact statement is optional.
     if ($node->get('field_impact_statement')->count()) {

--- a/src/modules/jcms_rest/src/Plugin/rest/resource/PersonItemRestResource.php
+++ b/src/modules/jcms_rest/src/Plugin/rest/resource/PersonItemRestResource.php
@@ -44,10 +44,7 @@ class PersonItemRestResource extends AbstractRestResourceBase {
       $response = [
         'id' => $id,
         'type' => $node->get('field_person_type')->getString(),
-        'name' => [
-          'preferred' => $node->getTitle(),
-          'index' => $node->get('field_person_index_name')->getString(),
-        ],
+        'name' => $this->processPeopleNames($node->getTitle(), $node->get('field_person_index_name')),
       ];
 
       // Orcid is optional.

--- a/src/modules/jcms_rest/src/Plugin/rest/resource/PersonListRestResource.php
+++ b/src/modules/jcms_rest/src/Plugin/rest/resource/PersonListRestResource.php
@@ -101,10 +101,7 @@ class PersonListRestResource extends AbstractRestResourceBase {
     $item = [
       'id' => substr($node->uuid(), -8),
       'type' => $node->get('field_person_type')->getString(),
-      'name' => [
-        'preferred' => $node->getTitle(),
-        'index' => $node->get('field_person_index_name')->getString(),
-      ],
+      'name' => $this->processPeopleNames($node->getTitle(), $node->get('field_person_index_name')),
     ];
 
     // Orcid is optional.

--- a/src/modules/jcms_rest/src/Plugin/rest/resource/PressPackageItemRestResource.php
+++ b/src/modules/jcms_rest/src/Plugin/rest/resource/PressPackageItemRestResource.php
@@ -73,12 +73,7 @@ class PressPackageItemRestResource extends AbstractRestResourceBase {
         $response['mediaContacts'] = [];
         foreach ($node->get('field_media_contact') as $media_contact) {
           $media_contact_item = $media_contact->get('entity')->getTarget()->getValue();
-          $media_contact_values = [
-            'name' => [
-              'preferred' => $media_contact_item->get('field_block_preferred_name')->getString(),
-              'index' => $media_contact_item->get('field_block_index_name')->getString(),
-            ],
-          ];
+          $media_contact_values['name'] = $this->processPeopleNames($media_contact_item->get('field_block_preferred_name')->getString(), $media_contact_item->get('field_block_index_name'));
 
           // Media contact email is optional.
           if ($media_contact_item->get('field_block_email')->count()) {

--- a/sync/core.entity_form_display.node.annual_report.default.yml
+++ b/sync/core.entity_form_display.node.annual_report.default.yml
@@ -10,6 +10,7 @@ dependencies:
     - image.style.thumbnail
     - node.type.annual_report
   module:
+    - content_moderation
     - image
     - link
     - text
@@ -19,27 +20,27 @@ bundle: annual_report
 mode: default
 content:
   field_annual_report_uri:
-    weight: 32
+    weight: 3
     settings:
       placeholder_url: ''
       placeholder_title: ''
     third_party_settings: {  }
     type: link_default
   field_annual_report_year:
-    weight: 31
+    weight: 2
     settings:
       placeholder: ''
     third_party_settings: {  }
     type: number
   field_image:
-    weight: 34
+    weight: 1
     settings:
       preview_image_style: thumbnail
       progress_indicator: bar
     third_party_settings: {  }
     type: image_image
   field_impact_statement:
-    weight: 33
+    weight: 4
     settings:
       rows: 5
       placeholder: ''
@@ -47,7 +48,7 @@ content:
     type: text_textarea
   title:
     type: string_textfield
-    weight: -5
+    weight: 0
     settings:
       size: 60
       placeholder: ''

--- a/sync/core.entity_form_display.node.blog_article.default.yml
+++ b/sync/core.entity_form_display.node.blog_article.default.yml
@@ -21,13 +21,13 @@ bundle: blog_article
 mode: default
 content:
   field_community_list:
-    weight: 35
+    weight: 5
     settings:
       display_label: true
     third_party_settings: {  }
     type: boolean_checkbox
   field_content:
-    weight: 32
+    weight: 3
     settings:
       title: 'Content item'
       title_plural: 'Content items'
@@ -38,21 +38,21 @@ content:
     third_party_settings: {  }
     type: entity_reference_paragraphs
   field_image:
-    weight: 33
+    weight: 1
     settings:
       progress_indicator: throbber
       preview_image_style: thumbnail
     third_party_settings: {  }
     type: image_image
   field_impact_statement:
-    weight: 31
+    weight: 2
     settings:
       rows: 5
       placeholder: ''
     third_party_settings: {  }
     type: text_textarea
   field_subjects:
-    weight: 34
+    weight: 4
     settings:
       match_operator: CONTAINS
       size: 60
@@ -61,7 +61,7 @@ content:
     type: entity_reference_autocomplete
   title:
     type: string_textfield
-    weight: -5
+    weight: 0
     settings:
       size: 60
       placeholder: ''

--- a/sync/core.entity_form_display.node.collection.default.yml
+++ b/sync/core.entity_form_display.node.collection.default.yml
@@ -14,6 +14,7 @@ dependencies:
     - image.style.thumbnail
     - node.type.collection
   module:
+    - content_moderation
     - image
     - inline_entity_form
     - text
@@ -23,19 +24,19 @@ bundle: collection
 mode: default
 content:
   field_collection_content:
-    weight: 36
+    weight: 6
     settings:
       form_mode: default
-      label_singular: ''
-      label_plural: ''
-      allow_new: true
+      override_labels: true
+      label_singular: 'collection item'
+      label_plural: 'collection items'
       allow_existing: true
       match_operator: STARTS_WITH
-      override_labels: false
+      allow_new: false
     third_party_settings: {  }
     type: inline_entity_form_complex
   field_collection_podcasts:
-    weight: 37
+    weight: 7
     settings:
       match_operator: CONTAINS
       size: 60
@@ -43,13 +44,13 @@ content:
     third_party_settings: {  }
     type: entity_reference_autocomplete
   field_community_list:
-    weight: 38
+    weight: 8
     settings:
       display_label: true
     third_party_settings: {  }
     type: boolean_checkbox
   field_curators:
-    weight: 35
+    weight: 5
     settings:
       match_operator: CONTAINS
       size: 60
@@ -57,21 +58,21 @@ content:
     third_party_settings: {  }
     type: entity_reference_autocomplete
   field_image:
-    weight: 33
+    weight: 1
     settings:
       progress_indicator: throbber
       preview_image_style: thumbnail
     third_party_settings: {  }
     type: image_image
   field_impact_statement:
-    weight: 32
+    weight: 3
     settings:
       rows: 5
       placeholder: ''
     third_party_settings: {  }
     type: text_textarea
   field_subjects:
-    weight: 34
+    weight: 4
     settings:
       match_operator: CONTAINS
       size: 60
@@ -79,7 +80,7 @@ content:
     third_party_settings: {  }
     type: entity_reference_autocomplete
   field_subtitle:
-    weight: 31
+    weight: 2
     settings:
       size: 60
       placeholder: ''
@@ -87,7 +88,7 @@ content:
     type: string_textfield
   title:
     type: string_textfield
-    weight: -5
+    weight: 0
     settings:
       size: 60
       placeholder: ''

--- a/sync/core.entity_form_display.node.highlight_item.default.yml
+++ b/sync/core.entity_form_display.node.highlight_item.default.yml
@@ -9,6 +9,7 @@ dependencies:
     - image.style.thumbnail
     - node.type.highlight_item
   module:
+    - content_moderation
     - image
 id: node.highlight_item.default
 targetEntityType: node
@@ -16,7 +17,7 @@ bundle: highlight_item
 mode: default
 content:
   field_author_line:
-    weight: 1
+    weight: 2
     settings:
       size: 60
       placeholder: ''
@@ -31,7 +32,7 @@ content:
     third_party_settings: {  }
     type: entity_reference_autocomplete
   field_image:
-    weight: 2
+    weight: 1
     settings:
       progress_indicator: throbber
       preview_image_style: thumbnail

--- a/sync/core.entity_form_display.node.interview.default.yml
+++ b/sync/core.entity_form_display.node.interview.default.yml
@@ -11,6 +11,7 @@ dependencies:
     - field.field.node.interview.field_person_preferred_name
     - node.type.interview
   module:
+    - content_moderation
     - paragraphs
     - text
 id: node.interview.default
@@ -19,23 +20,24 @@ bundle: interview
 mode: default
 content:
   field_community_list:
-    weight: 26
+    weight: 6
     settings:
       display_label: true
     third_party_settings: {  }
     type: boolean_checkbox
   field_content:
-    weight: 10
+    weight: 4
     settings:
       title: 'Content item'
       title_plural: 'Content items'
       edit_mode: open
       add_mode: dropdown
       form_display_mode: default
+      default_paragraph_type: ''
     third_party_settings: {  }
     type: entity_reference_paragraphs
   field_impact_statement:
-    weight: 9
+    weight: 3
     settings:
       rows: 5
       placeholder: ''
@@ -43,23 +45,24 @@ content:
     type: text_textarea
   field_interview_cv:
     type: entity_reference_paragraphs
-    weight: 7
+    weight: 5
     settings:
       title: Paragraph
       title_plural: Paragraphs
       edit_mode: open
       add_mode: dropdown
       form_display_mode: default
+      default_paragraph_type: ''
     third_party_settings: {  }
   field_person_index_name:
-    weight: 6
+    weight: 1
     settings:
       size: 60
       placeholder: ''
     third_party_settings: {  }
     type: string_textfield
   field_person_preferred_name:
-    weight: 5
+    weight: 0
     settings:
       size: 60
       placeholder: ''
@@ -67,7 +70,7 @@ content:
     type: string_textfield
   title:
     type: string_textfield
-    weight: 8
+    weight: 2
     settings:
       size: 60
       placeholder: ''

--- a/sync/core.entity_form_display.node.labs_experiment.default.yml
+++ b/sync/core.entity_form_display.node.labs_experiment.default.yml
@@ -11,6 +11,7 @@ dependencies:
     - image.style.thumbnail
     - node.type.labs_experiment
   module:
+    - content_moderation
     - image
     - paragraphs
     - text
@@ -20,7 +21,7 @@ bundle: labs_experiment
 mode: default
 content:
   field_community_list:
-    weight: 26
+    weight: 5
     settings:
       display_label: true
     third_party_settings: {  }
@@ -34,6 +35,7 @@ content:
       edit_mode: open
       add_mode: dropdown
       form_display_mode: default
+      default_paragraph_type: ''
     third_party_settings: {  }
   field_experiment_number:
     weight: 0
@@ -42,14 +44,14 @@ content:
     third_party_settings: {  }
     type: number
   field_image:
-    weight: 7
+    weight: 1
     settings:
       progress_indicator: throbber
       preview_image_style: thumbnail
     third_party_settings: {  }
     type: image_image
   field_impact_statement:
-    weight: 2
+    weight: 3
     settings:
       rows: 5
       placeholder: ''
@@ -57,7 +59,7 @@ content:
     type: text_textarea
   title:
     type: string_textfield
-    weight: 1
+    weight: 2
     settings:
       size: 60
       placeholder: ''

--- a/sync/core.entity_form_display.node.person.default.yml
+++ b/sync/core.entity_form_display.node.person.default.yml
@@ -13,6 +13,7 @@ dependencies:
     - image.style.thumbnail
     - node.type.person
   module:
+    - content_moderation
     - image
     - paragraphs
     - text
@@ -22,28 +23,28 @@ bundle: person
 mode: default
 content:
   field_image:
-    weight: 7
+    weight: 2
     settings:
       progress_indicator: throbber
       preview_image_style: thumbnail
     third_party_settings: {  }
     type: image_image
   field_person_competing:
-    weight: 9
+    weight: 5
     settings:
       rows: 5
       placeholder: ''
     third_party_settings: {  }
     type: text_textarea
   field_person_index_name:
-    weight: 2
+    weight: 1
     settings:
       size: 60
       placeholder: ''
     third_party_settings: {  }
     type: string_textfield
   field_person_orcid:
-    weight: 8
+    weight: 4
     settings:
       size: 60
       placeholder: ''
@@ -51,28 +52,30 @@ content:
     type: string_textfield
   field_person_profile:
     type: entity_reference_paragraphs
-    weight: 10
+    weight: 6
     settings:
       title: 'Profile item'
       title_plural: 'Profile items'
       edit_mode: open
       add_mode: dropdown
       form_display_mode: default
+      default_paragraph_type: ''
     third_party_settings: {  }
   field_person_type:
-    weight: 6
+    weight: 3
     settings: {  }
     third_party_settings: {  }
     type: options_select
   field_research_details:
     type: entity_reference_paragraphs
-    weight: 11
+    weight: 7
     settings:
       title: 'Research details'
       title_plural: 'Research details'
       edit_mode: open
       add_mode: dropdown
       form_display_mode: default
+      default_paragraph_type: ''
     third_party_settings: {  }
   title:
     type: string_textfield

--- a/sync/core.entity_form_display.node.podcast_episode.default.yml
+++ b/sync/core.entity_form_display.node.podcast_episode.default.yml
@@ -42,27 +42,27 @@ content:
     third_party_settings: {  }
     type: inline_entity_form_complex
   field_episode_mp3:
-    weight: 3
+    weight: 4
     settings:
       placeholder_url: ''
       placeholder_title: ''
     third_party_settings: {  }
     type: link_default
   field_episode_number:
-    weight: 1
+    weight: 2
     settings:
       placeholder: ''
     third_party_settings: {  }
     type: number
   field_image:
-    weight: 4
+    weight: 1
     settings:
       progress_indicator: throbber
       preview_image_style: thumbnail
     third_party_settings: {  }
     type: image_image
   field_impact_statement:
-    weight: 2
+    weight: 3
     settings:
       rows: 5
       placeholder: ''

--- a/sync/core.entity_form_display.node.press_package.default.yml
+++ b/sync/core.entity_form_display.node.press_package.default.yml
@@ -10,6 +10,7 @@ dependencies:
     - field.field.node.press_package.field_related_content
     - node.type.press_package
   module:
+    - content_moderation
     - inline_entity_form
     - paragraphs
     - text
@@ -26,6 +27,7 @@ content:
       edit_mode: open
       add_mode: dropdown
       form_display_mode: default
+      default_paragraph_type: ''
     third_party_settings: {  }
     type: entity_reference_paragraphs
   field_impact_statement:
@@ -44,6 +46,7 @@ content:
       edit_mode: open
       add_mode: dropdown
       form_display_mode: default
+      default_paragraph_type: ''
     third_party_settings: {  }
   field_press_package_about:
     type: entity_reference_paragraphs
@@ -54,17 +57,18 @@ content:
       edit_mode: open
       add_mode: dropdown
       form_display_mode: default
+      default_paragraph_type: ''
     third_party_settings: {  }
   field_related_content:
     weight: 28
     settings:
       form_mode: default
-      label_singular: ''
-      label_plural: ''
-      allow_new: true
+      override_labels: true
+      label_singular: article
+      label_plural: articles
       allow_existing: true
       match_operator: STARTS_WITH
-      override_labels: false
+      allow_new: false
     third_party_settings: {  }
     type: inline_entity_form_complex
   title:

--- a/sync/field.field.node.annual_report.field_image.yml
+++ b/sync/field.field.node.annual_report.field_image.yml
@@ -11,7 +11,7 @@ id: node.annual_report.field_image
 field_name: field_image
 entity_type: node
 bundle: annual_report
-label: Image
+label: 'Image (thumbnail)'
 description: ''
 required: true
 translatable: true

--- a/sync/field.field.node.blog_article.field_image.yml
+++ b/sync/field.field.node.blog_article.field_image.yml
@@ -11,7 +11,7 @@ id: node.blog_article.field_image
 field_name: field_image
 entity_type: node
 bundle: blog_article
-label: Image
+label: 'Image (banner)'
 description: ''
 required: false
 translatable: true

--- a/sync/field.field.node.blog_article.field_subjects.yml
+++ b/sync/field.field.node.blog_article.field_subjects.yml
@@ -11,7 +11,7 @@ field_name: field_subjects
 entity_type: node
 bundle: blog_article
 label: Subjects
-description: ''
+description: 'Major subject areas'
 required: false
 translatable: true
 default_value: {  }

--- a/sync/field.field.node.collection.field_image.yml
+++ b/sync/field.field.node.collection.field_image.yml
@@ -11,7 +11,7 @@ id: node.collection.field_image
 field_name: field_image
 entity_type: node
 bundle: collection
-label: Image
+label: 'Image (banner)'
 description: ''
 required: true
 translatable: true
@@ -22,7 +22,7 @@ settings:
   file_extensions: 'png gif jpg jpeg'
   max_filesize: ''
   max_resolution: ''
-  min_resolution: ''
+  min_resolution: 1800x900
   alt_field: true
   alt_field_required: false
   title_field: false

--- a/sync/field.field.node.collection.field_subjects.yml
+++ b/sync/field.field.node.collection.field_subjects.yml
@@ -11,7 +11,7 @@ field_name: field_subjects
 entity_type: node
 bundle: collection
 label: Subjects
-description: ''
+description: 'Major subject areas'
 required: false
 translatable: true
 default_value: {  }

--- a/sync/field.field.node.cover.field_image.yml
+++ b/sync/field.field.node.cover.field_image.yml
@@ -11,7 +11,7 @@ id: node.cover.field_image
 field_name: field_image
 entity_type: node
 bundle: cover
-label: Image
+label: 'Image (banner)'
 description: ''
 required: true
 translatable: true

--- a/sync/field.field.node.highlight_item.field_image.yml
+++ b/sync/field.field.node.highlight_item.field_image.yml
@@ -11,7 +11,7 @@ id: node.highlight_item.field_image
 field_name: field_image
 entity_type: node
 bundle: highlight_item
-label: Image
+label: 'Image (thumbnail)'
 description: ''
 required: false
 translatable: true

--- a/sync/field.field.node.interview.field_content.yml
+++ b/sync/field.field.node.interview.field_content.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - field.storage.node.field_content
     - node.type.interview
+    - paragraphs.paragraphs_type.image
     - paragraphs.paragraphs_type.paragraph
     - paragraphs.paragraphs_type.question
   module:
@@ -23,40 +24,56 @@ settings:
   handler: 'default:paragraph'
   handler_settings:
     target_bundles:
-      paragraph: paragraph
       question: question
+      paragraph: paragraph
+      image: image
     target_bundles_drag_drop:
-      blockquote:
-        weight: 12
-        enabled: false
-      cv_item:
-        weight: 13
-        enabled: false
-      image:
-        weight: 14
-        enabled: false
-      list:
-        weight: 15
-        enabled: false
-      list_item:
-        weight: 16
-        enabled: false
-      paragraph:
-        enabled: true
-        weight: 17
       question:
         enabled: true
-        weight: 18
+        weight: -33
+      paragraph:
+        enabled: true
+        weight: -32
+      image:
+        enabled: true
+        weight: -31
+      blockquote:
+        weight: -30
+        enabled: false
+      cv_item:
+        weight: -29
+        enabled: false
+      list:
+        weight: -28
+        enabled: false
+      list_item:
+        weight: -27
+        enabled: false
+      button:
+        weight: -26
+        enabled: false
+      code:
+        weight: -25
+        enabled: false
       research_details:
-        weight: 19
+        weight: -24
         enabled: false
       section:
-        weight: 20
+        weight: -23
         enabled: false
       table:
-        weight: 21
+        weight: -22
+        enabled: false
+      json:
+        weight: -21
         enabled: false
       youtube:
-        weight: 22
+        weight: -20
+        enabled: false
+      media_contact:
+        weight: -19
+        enabled: false
+      venue:
+        weight: -18
         enabled: false
 field_type: entity_reference_revisions

--- a/sync/field.field.node.interview.field_person_index_name.yml
+++ b/sync/field.field.node.interview.field_person_index_name.yml
@@ -10,8 +10,8 @@ field_name: field_person_index_name
 entity_type: node
 bundle: interview
 label: 'Interviewee index name'
-description: "This is the name that should be used for indexing people.\r\n\r\nFor example:\r\n<ul>\r\n  <li>Schekman, Randy</li>\r\n  <li>VijayRaghavan, Krishnaswamy</li>\r\n  <li>Wenhui Li</li>\r\n</ul>"
-required: true
+description: "<em>Leave blank to autogenerate this value from the preferred name</em><br />This is the name that should be used for indexing people.\r\n\r\nFor example:\r\n<ul>\r\n  <li>Schekman, Randy</li>\r\n  <li>VijayRaghavan, Krishnaswamy</li>\r\n  <li>Wenhui Li</li>\r\n</ul>"
+required: false
 translatable: true
 default_value: {  }
 default_value_callback: ''

--- a/sync/field.field.node.labs_experiment.field_image.yml
+++ b/sync/field.field.node.labs_experiment.field_image.yml
@@ -11,7 +11,7 @@ id: node.labs_experiment.field_image
 field_name: field_image
 entity_type: node
 bundle: labs_experiment
-label: Image
+label: 'Image (banner)'
 description: ''
 required: true
 translatable: true

--- a/sync/field.field.node.person.field_image.yml
+++ b/sync/field.field.node.person.field_image.yml
@@ -11,7 +11,7 @@ id: node.person.field_image
 field_name: field_image
 entity_type: node
 bundle: person
-label: Image
+label: 'Image (thumbnail)'
 description: ''
 required: false
 translatable: true
@@ -22,7 +22,7 @@ settings:
   file_extensions: 'png gif jpg jpeg'
   max_filesize: ''
   max_resolution: ''
-  min_resolution: 500x282
+  min_resolution: 500x281
   alt_field: true
   alt_field_required: false
   title_field: false

--- a/sync/field.field.node.person.field_person_index_name.yml
+++ b/sync/field.field.node.person.field_person_index_name.yml
@@ -10,8 +10,8 @@ field_name: field_person_index_name
 entity_type: node
 bundle: person
 label: 'Index name'
-description: "This is the name that should be used for indexing people.\r\n\r\nFor example:\r\n<ul>\r\n  <li>Schekman, Randy</li>\r\n  <li>VijayRaghavan, Krishnaswamy</li>\r\n  <li>Wenhui Li</li>\r\n</ul>"
-required: true
+description: "<em>Leave blank to autogenerate this value from the preferred name</em><br />This is the name that should be used for indexing people.\r\n\r\nFor example:\r\n<ul>\r\n  <li>Schekman, Randy</li>\r\n  <li>VijayRaghavan, Krishnaswamy</li>\r\n  <li>Wenhui Li</li>\r\n</ul>"
+required: false
 translatable: false
 default_value: {  }
 default_value_callback: ''

--- a/sync/field.field.node.podcast_episode.field_image.yml
+++ b/sync/field.field.node.podcast_episode.field_image.yml
@@ -11,7 +11,7 @@ id: node.podcast_episode.field_image
 field_name: field_image
 entity_type: node
 bundle: podcast_episode
-label: Image
+label: 'Image (banner)'
 description: ''
 required: true
 translatable: false

--- a/sync/field.field.node.podcast_episode.field_subjects.yml
+++ b/sync/field.field.node.podcast_episode.field_subjects.yml
@@ -11,7 +11,7 @@ field_name: field_subjects
 entity_type: node
 bundle: podcast_episode
 label: Subjects
-description: ''
+description: 'Major subject areas'
 required: false
 translatable: false
 default_value: {  }

--- a/sync/field.field.node.press_package.field_related_content.yml
+++ b/sync/field.field.node.press_package.field_related_content.yml
@@ -11,7 +11,7 @@ field_name: field_related_content
 entity_type: node
 bundle: press_package
 label: 'Related content'
-description: ''
+description: 'Manuscript ID (e.g. 00666)'
 required: true
 translatable: false
 default_value: {  }

--- a/sync/field.field.paragraph.media_contact.field_block_index_name.yml
+++ b/sync/field.field.paragraph.media_contact.field_block_index_name.yml
@@ -10,8 +10,8 @@ field_name: field_block_index_name
 entity_type: paragraph
 bundle: media_contact
 label: 'Index name'
-description: "This is the name that should be used for indexing people.\r\n\r\nFor example:\r\n<ul>\r\n  <li>Schekman, Randy</li>\r\n  <li>VijayRaghavan, Krishnaswamy</li>\r\n  <li>Wenhui Li</li>\r\n</ul>"
-required: true
+description: "<em>Leave blank to autogenerate this value from the preferred name</em><br />This is the name that should be used for indexing people.\r\n\r\nFor example:\r\n<ul>\r\n  <li>Schekman, Randy</li>\r\n  <li>VijayRaghavan, Krishnaswamy</li>\r\n  <li>Wenhui Li</li>\r\n</ul>"
+required: false
 translatable: false
 default_value: {  }
 default_value_callback: ''

--- a/sync/field.field.paragraph.research_details.field_research_expertises.yml
+++ b/sync/field.field.paragraph.research_details.field_research_expertises.yml
@@ -11,7 +11,7 @@ field_name: field_research_expertises
 entity_type: paragraph
 bundle: research_details
 label: Expertises
-description: ''
+description: 'Major subject areas'
 required: true
 translatable: false
 default_value: {  }

--- a/sync/field.storage.paragraph.field_research_expertises.yml
+++ b/sync/field.storage.paragraph.field_research_expertises.yml
@@ -3,8 +3,12 @@ langcode: en
 status: true
 dependencies:
   module:
+    - field_permissions
     - paragraphs
     - taxonomy
+third_party_settings:
+  field_permissions:
+    permission_type: public
 id: paragraph.field_research_expertises
 field_name: field_research_expertises
 entity_type: paragraph

--- a/sync/paragraphs.paragraphs_type.blockquote.yml
+++ b/sync/paragraphs.paragraphs_type.blockquote.yml
@@ -4,4 +4,5 @@ status: true
 dependencies: {  }
 id: blockquote
 label: Blockquote
+icon_uuid: null
 behavior_plugins: {  }

--- a/sync/paragraphs.paragraphs_type.button.yml
+++ b/sync/paragraphs.paragraphs_type.button.yml
@@ -4,4 +4,5 @@ status: true
 dependencies: {  }
 id: button
 label: Button
+icon_uuid: null
 behavior_plugins: {  }

--- a/sync/paragraphs.paragraphs_type.code.yml
+++ b/sync/paragraphs.paragraphs_type.code.yml
@@ -4,4 +4,5 @@ status: true
 dependencies: {  }
 id: code
 label: Code
+icon_uuid: null
 behavior_plugins: {  }

--- a/sync/paragraphs.paragraphs_type.cv_item.yml
+++ b/sync/paragraphs.paragraphs_type.cv_item.yml
@@ -4,4 +4,5 @@ status: true
 dependencies: {  }
 id: cv_item
 label: 'CV item'
+icon_uuid: null
 behavior_plugins: {  }

--- a/sync/paragraphs.paragraphs_type.image.yml
+++ b/sync/paragraphs.paragraphs_type.image.yml
@@ -4,4 +4,5 @@ status: true
 dependencies: {  }
 id: image
 label: Image
+icon_uuid: null
 behavior_plugins: {  }

--- a/sync/paragraphs.paragraphs_type.json.yml
+++ b/sync/paragraphs.paragraphs_type.json.yml
@@ -4,4 +4,5 @@ status: true
 dependencies: {  }
 id: json
 label: JSON
+icon_uuid: null
 behavior_plugins: {  }

--- a/sync/paragraphs.paragraphs_type.list.yml
+++ b/sync/paragraphs.paragraphs_type.list.yml
@@ -4,4 +4,5 @@ status: true
 dependencies: {  }
 id: list
 label: List
+icon_uuid: null
 behavior_plugins: {  }

--- a/sync/paragraphs.paragraphs_type.list_item.yml
+++ b/sync/paragraphs.paragraphs_type.list_item.yml
@@ -4,4 +4,5 @@ status: true
 dependencies: {  }
 id: list_item
 label: 'List item'
+icon_uuid: null
 behavior_plugins: {  }

--- a/sync/paragraphs.paragraphs_type.media_contact.yml
+++ b/sync/paragraphs.paragraphs_type.media_contact.yml
@@ -4,4 +4,5 @@ status: true
 dependencies: {  }
 id: media_contact
 label: 'Media contact'
+icon_uuid: null
 behavior_plugins: {  }

--- a/sync/paragraphs.paragraphs_type.paragraph.yml
+++ b/sync/paragraphs.paragraphs_type.paragraph.yml
@@ -4,4 +4,5 @@ status: true
 dependencies: {  }
 id: paragraph
 label: Paragraph
+icon_uuid: null
 behavior_plugins: {  }

--- a/sync/paragraphs.paragraphs_type.question.yml
+++ b/sync/paragraphs.paragraphs_type.question.yml
@@ -4,4 +4,5 @@ status: true
 dependencies: {  }
 id: question
 label: Question
+icon_uuid: null
 behavior_plugins: {  }

--- a/sync/paragraphs.paragraphs_type.research_details.yml
+++ b/sync/paragraphs.paragraphs_type.research_details.yml
@@ -4,4 +4,5 @@ status: true
 dependencies: {  }
 id: research_details
 label: 'Research details'
+icon_uuid: null
 behavior_plugins: {  }

--- a/sync/paragraphs.paragraphs_type.section.yml
+++ b/sync/paragraphs.paragraphs_type.section.yml
@@ -4,4 +4,5 @@ status: true
 dependencies: {  }
 id: section
 label: Section
+icon_uuid: null
 behavior_plugins: {  }

--- a/sync/paragraphs.paragraphs_type.table.yml
+++ b/sync/paragraphs.paragraphs_type.table.yml
@@ -4,4 +4,5 @@ status: true
 dependencies: {  }
 id: table
 label: Table
+icon_uuid: null
 behavior_plugins: {  }

--- a/sync/paragraphs.paragraphs_type.venue.yml
+++ b/sync/paragraphs.paragraphs_type.venue.yml
@@ -4,4 +4,5 @@ status: true
 dependencies: {  }
 id: venue
 label: Venue
+icon_uuid: null
 behavior_plugins: {  }

--- a/sync/paragraphs.paragraphs_type.youtube.yml
+++ b/sync/paragraphs.paragraphs_type.youtube.yml
@@ -4,4 +4,5 @@ status: true
 dependencies: {  }
 id: youtube
 label: 'YouTube video'
+icon_uuid: null
 behavior_plugins: {  }


### PR DESCRIPTION
Should address the following admin UI issues:

* In the published articles, “, basic_html” appears after each of the CV entries
* Images permitted in interviews content
* Add description to "Subjects" ("Major subject area")
* I would prefer the upload page to be ordered so that the CV upload section came at the end of the page
* Index name can be left blank and generated from preferred name
* Add interview to collection when created
* Linking to articles is easier (removed option to create articles - can only referencing existing)
* Improved error message when content field left blank (was: this value should not be null)
* Improved label of images (banner or thumbnail)
* Improved description and label on related content field for press packages