### PR TITLE
Correct exit code for checking migrations result

### DIFF
--- a/check-drush-migrate-output.sh
+++ b/check-drush-migrate-output.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -e
 
-grep -c SQLSTATE -
+exit "$(grep -c SQLSTATE -)"


### PR DESCRIPTION
The scripts checks the text, but prints rather than returning the exit code