### PR TITLE
Clean database on rollback

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,7 +15,12 @@ elifePipeline {
             deploy: [
                 stackname: 'journal-cms--end2end',
                 revision: commit,
-                folder: '/srv/journal-cms'
+                folder: '/srv/journal-cms',
+                rollbackStep: {
+                    builderCmd 'journal-cms--end2end', 'cd /srv/journal-cms/web && ../vendor/bin/drush si config_installer -y && ../vendor/bin/drush cr'
+                    builderDeployRevision 'journal-cms--end2end', 'approved'
+                    builderSmokeTests 'journal-cms--end2end', '/srv/journal-cms'
+                }
             ],
             marker: 'journal_cms'
         )


### PR DESCRIPTION
The default rollback step will change the version of the code being required and run a new salt highstate. This doesn't play well with the journal-cms database.

Therefore, this custom rollback step cleans the database instead and
reinstalls the older commit, but without existing state getting in the
way. We lose a bit of useful feedback here because end2end is not as
stateful as production, but we gain in stability as code that is broken
does not stay deployed, and other projects may run end2end again
successfully.