### PR TITLE
ELPP-2346: Setup monolog to write Drupal::logger() to file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,9 +2,11 @@
 .idea/
 .vagrant/
 config/local.settings.php
+config/local.services.yml
 scripts/legacy_cms.sql.gz
 scripts/legacy_cms_files/
 scripts/legacy_cms_files_alt/
 vendor/
 web/
 console/
+private/

--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,9 @@
     "drupal/diff": "^1.0@RC",
     "embed/embed": "^3.0",
     "drupal/devel": "1.x-dev",
-    "drupal/core": "~8.3.0"
+    "drupal/core": "~8.3.0",
+    "drupal/monolog": "^1.0@alpha",
+    "monolog/monolog": "~1.6"
   },
   "require-dev": {
     "drupal/drupal-extension": "~3.0",
@@ -80,7 +82,7 @@
     ]
   },
   "scripts": {
-    "clean-up": "chmod -R 755 web/ && rm -rf config/local.settings.php web/ vendor/",
+    "clean-up": "chmod -R 755 web/ && rm -rf config/local.settings.php web/ vendor/ private/",
     "drupal-scaffold": "DrupalComposer\\DrupalScaffold\\Plugin::scaffold",
     "post-install-cmd": [
       "DrupalComposer\\DrupalScaffold\\Plugin::scaffold",
@@ -130,6 +132,9 @@
       },
       "drupal/paragraphs": {
         "Empty required fields not providing meaningful error messages": "https://www.drupal.org/files/issues/empty_required_fields-2788607-70.patch"
+      },
+      "drupal/monolog": {
+        "UidProcessor missing class": "https://www.drupal.org/files/issues/uidprocessor_missing-2871806-2.patch"
       }
     }
   }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "1777e5276b9f3056a05908ccf89b6980",
+    "content-hash": "2fb208af88a74fbd10230b586dce3542",
     "packages": [
         {
             "name": "alchemy/zippy",
@@ -2401,7 +2401,7 @@
             "dist": {
                 "type": "zip",
                 "url": "https://ftp.drupal.org/files/projects/ctools-8.x-3.0-beta2.zip",
-                "reference": null,
+                "reference": "8.x-3.0-beta2",
                 "shasum": "6deece503cca328dde9b573a5d8a8fc74798d284"
             },
             "require": {
@@ -3207,6 +3207,66 @@
             "homepage": "https://www.drupal.org/project/migrate_tools",
             "support": {
                 "source": "http://cgit.drupalcode.org/migrate_tools"
+            }
+        },
+        {
+            "name": "drupal/monolog",
+            "version": "1.0.0-alpha2",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupal.org/project/monolog",
+                "reference": "8.x-1.0-alpha2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/monolog-8.x-1.0-alpha2.zip",
+                "reference": "8.x-1.0-alpha2",
+                "shasum": "1360d3a75987ffcee32add3eb629aba7b277f471"
+            },
+            "require": {
+                "drupal/core": "~8.0",
+                "monolog/monolog": ">=1.6.0,<2.0.0"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "branch-alias": {
+                    "dev-1.x": "1.x-dev"
+                },
+                "drupal": {
+                    "version": "8.x-1.0-alpha2",
+                    "datestamp": "1455725644"
+                },
+                "patches_applied": {
+                    "UidProcessor missing class": "https://www.drupal.org/files/issues/uidprocessor_missing-2871806-2.patch"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Drupal\\Monolog": "src/"
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Chris Pliakas",
+                    "homepage": "https://www.drupal.org/user/1011436",
+                    "email": "opensource@chrispliakas.com",
+                    "role": "Project Lead"
+                },
+                {
+                    "name": "See contributors",
+                    "homepage": "http://drupal.org/node/1937716/committers",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A Framework and UI for integrating with the Monolog library.",
+            "homepage": "http://drupal.org/project/monolog",
+            "support": {
+                "source": "http://cgit.drupalcode.org/monolog",
+                "issues": "http://drupal.org/project/issues/monolog"
             }
         },
         {
@@ -9802,6 +9862,7 @@
         "drupal/focal_point": 10,
         "drupal/diff": 5,
         "drupal/devel": 20,
+        "drupal/monolog": 15,
         "elife/api": 20,
         "elife/api-validator": 20
     },

--- a/config/drupal-vm.services.yml
+++ b/config/drupal-vm.services.yml
@@ -1,0 +1,22 @@
+parameters:
+  monolog.channel_handlers:
+    default: ['default_handler', 'error_handler']
+  monolog.processors: ['process_id', 'message_placeholder', 'current_user', 'request_uri', 'ip', 'referer']
+
+services:
+  jcms.monolog.formatter_basic:
+    class: Monolog\Formatter\JsonFormatter
+  jcms.monolog.formatter_advanced:
+    class: Monolog\Formatter\JsonFormatter
+    calls:
+      - [includeStacktraces, []]
+  monolog.handler.default_handler:
+    class: Monolog\Handler\StreamHandler
+    arguments: ['private://monolog/all.json']
+    calls:
+      - [setFormatter, ['@jcms.monolog.formatter_basic']]
+  monolog.handler.error_handler:
+    class: Monolog\Handler\StreamHandler
+    arguments: ['private://monolog/error.json', 400]
+    calls:
+      - [setFormatter, ['@jcms.monolog.formatter_advanced']]

--- a/config/drupal-vm.settings.php
+++ b/config/drupal-vm.settings.php
@@ -75,6 +75,12 @@ else {
   error_log('Redis cache backend is unavailable.');
 }
 
+if (file_exists(DRUPAL_ROOT . '/../config/local.services.yml')) {
+  $settings['container_yamls'][] = DRUPAL_ROOT . '/../config/local.services.yml';
+}
+
+$settings['file_private_path'] = './../private';
+
 $settings['jcms_sqs_endpoint'] = 'http://localhost:4100';
 $settings['jcms_sqs_queue'] = 'journal-cms--queue-local';
 // Production template is 'arn:aws:sns:us-east-1:512686554592:bus-%s--dev'.

--- a/scripts/composer/ScriptHandler.php
+++ b/scripts/composer/ScriptHandler.php
@@ -20,22 +20,54 @@ class ScriptHandler extends DrupalScriptHandler {
     $config_root = $root . '/config';
     $src_root = $root . '/src';
     parent::createRequiredFiles($event);
+
     if ($fs->exists($config_root . '/settings.php')) {
       if ($fs->exists($drupal_root . '/sites/default/settings.php')) {
         $fs->chmod($drupal_root . '/sites/default', 0755);
         $fs->remove($drupal_root . '/sites/default/settings.php');
       }
       $fs->copy($config_root . '/settings.php', $drupal_root . '/sites/default/settings.php');
-      $fs->chmod($drupal_root . '/sites/default/settings.php', 0755);
-      $event->getIO()->write('Create a sites/default/settings.php file from local config with chmod 0666');
+      $fs->chmod($drupal_root . '/sites/default/settings.php', 0666);
     }
 
     if (!$fs->exists($config_root . '/local.settings.php')) {
       $fs->copy($config_root . '/drupal-vm.settings.php', $config_root . '/local.settings.php');
     }
 
+    // Create private folder, with known sub-folders.
+    $local_settings = str_replace('"', "'", file_get_contents($config_root . '/local.settings.php'));
+    if (preg_match("/'file_private_path'[^']+'(?P<file_private_path>[^']+)/", $local_settings, $match)) {
+      $file_private_path = rtrim($match['file_private_path'], '/');
+
+      $file_private_path = preg_replace('~^\./~', '/', $file_private_path);
+
+      if (substr($match['file_private_path'], 0, 1) != '/') {
+        $file_private_path = $drupal_root . $file_private_path;
+      }
+
+      if (!$fs->exists($file_private_path)) {
+        $fs->mkdir($file_private_path, 0755);
+      }
+
+      $private_subfolders = ['monolog'];
+      foreach ($private_subfolders as $folder) {
+        if (!$fs->exists($file_private_path . '/' . $folder)) {
+          $fs->mkdir($file_private_path . '/' . $folder, 0755);
+        }
+      }
+    }
+
+    if (!$fs->exists($config_root . '/local.services.yml')) {
+      $fs->copy($config_root . '/drupal-vm.services.yml', $config_root . '/local.services.yml');
+    }
+
     // Create symlink to custom modules folder.
     if ($fs->exists($src_root . '/modules') && !$fs->exists($drupal_root . '/modules/custom')) {
+      $fs->symlink('../../src/modules', $drupal_root . '/modules/custom');
+    }
+
+    // Create symlink to custom modules folder.
+    if ($fs->exists($root . '/private')) {
       $fs->symlink('../../src/modules', $drupal_root . '/modules/custom');
     }
   }

--- a/sync/core.extension.yml
+++ b/sync/core.extension.yml
@@ -44,6 +44,7 @@ module:
   migrate: 0
   migrate_plus: 0
   migrate_tools: 0
+  monolog: 0
   node: 0
   options: 0
   page_cache: 0


### PR DESCRIPTION
An example of the output:

```
[2017-04-21 16:31:04] webprofiler.INFO: Info message [] {"referer":"","ip":"127.0.0.1","request_uri":"http://default/","uid":"0","user":""}
[2017-04-21 16:37:46] webprofiler.INFO: Info message [] {"memory_usage":"34 MB","referer":"","ip":"127.0.0.1","request_uri":"http://default/","uid":"0","user":""}
[2017-04-21 16:38:32] user.NOTICE: Session closed for admin. {"%name":"admin"} {"memory_usage":"6 MB","referer":"http://journal-cms.local/admin/modules","ip":"192.168.88.1","request_uri":"http://journal-cms.local/user/logout","uid":"1","user":"admin"}
[2017-04-21 16:38:37] access denied.WARNING: /admin/modules {"@uri":"/admin/modules"} {"memory_usage":"6 MB","referer":"","ip":"192.168.88.1","request_uri":"http://journal-cms.local/admin/modules","uid":0,"user":""}
[2017-04-21 16:45:20] php.ERROR: Error: Call to undefined function Exception() in eval() (line 1 of /var/www/journal-cms/vendor/drush/drush/commands/core/core.drush.inc(1168) : eval()'d code) #0 /var/www/journal-cms/vendor/drush/drush/commands/core/core.drush.inc(1168): eval() #1 /var/www/journal-cms/vendor/drush/drush/includes/command.inc(422): drush_core_php_eval('_drupal_log_err...') #2 /var/www/journal-cms/vendor/drush/drush/includes/command.inc(231): _drush_invoke_hooks(Array, Array) #3 /var/www/journal-cms/vendor/drush/drush/includes/command.inc(199): drush_command('_drupal_log_err...') #4 /var/www/journal-cms/vendor/drush/drush/lib/Drush/Boot/BaseBoot.php(67): drush_dispatch(Array) #5 /var/www/journal-cms/vendor/drush/drush/includes/preflight.inc(66): Drush\Boot\BaseBoot->bootstrap_and_dispatch() #6 /var/www/journal-cms/vendor/drush/drush/drush.php(12): drush_main() #7 {main}. {"%type":"Error","@message":"Call to undefined function Exception()","%function":"eval()","%file":"/var/www/journal-cms/vendor/drush/drush/commands/core/core.drush.inc(1168) : eval()'d code","%line":1,"severity_level":3,"@backtrace_string":"#0 /var/www/journal-cms/vendor/drush/drush/commands/core/core.drush.inc(1168): eval()\n#1 /var/www/journal-cms/vendor/drush/drush/includes/command.inc(422): drush_core_php_eval('_drupal_log_err...')\n#2 /var/www/journal-cms/vendor/drush/drush/includes/command.inc(231): _drush_invoke_hooks(Array, Array)\n#3 /var/www/journal-cms/vendor/drush/drush/includes/command.inc(199): drush_command('_drupal_log_err...')\n#4 /var/www/journal-cms/vendor/drush/drush/lib/Drush/Boot/BaseBoot.php(67): drush_dispatch(Array)\n#5 /var/www/journal-cms/vendor/drush/drush/includes/preflight.inc(66): Drush\\Boot\\BaseBoot->bootstrap_and_dispatch()\n#6 /var/www/journal-cms/vendor/drush/drush/drush.php(12): drush_main()\n#7 {main}"} {"memory_usage":"36 MB","referer":"","ip":"127.0.0.1","request_uri":"http://default/","uid":"0","user":""}
[2017-04-21 16:48:37] php.ERROR: Error: Call to undefined function Exception() in eval() (line 1 of /var/www/journal-cms/vendor/drush/drush/commands/core/core.drush.inc(1168) : eval()'d code) #0 /var/www/journal-cms/vendor/drush/drush/commands/core/core.drush.inc(1168): eval() #1 /var/www/journal-cms/vendor/drush/drush/includes/command.inc(422): drush_core_php_eval('_drupal_log_err...') #2 /var/www/journal-cms/vendor/drush/drush/includes/command.inc(231): _drush_invoke_hooks(Array, Array) #3 /var/www/journal-cms/vendor/drush/drush/includes/command.inc(199): drush_command('_drupal_log_err...') #4 /var/www/journal-cms/vendor/drush/drush/lib/Drush/Boot/BaseBoot.php(67): drush_dispatch(Array) #5 /var/www/journal-cms/vendor/drush/drush/includes/preflight.inc(66): Drush\Boot\BaseBoot->bootstrap_and_dispatch() #6 /var/www/journal-cms/vendor/drush/drush/drush.php(12): drush_main() #7 {main}. {"%type":"Error","@message":"Call to undefined function Exception()","%function":"eval()","%file":"/var/www/journal-cms/vendor/drush/drush/commands/core/core.drush.inc(1168) : eval()'d code","%line":1,"severity_level":3,"@backtrace_string":"#0 /var/www/journal-cms/vendor/drush/drush/commands/core/core.drush.inc(1168): eval()\n#1 /var/www/journal-cms/vendor/drush/drush/includes/command.inc(422): drush_core_php_eval('_drupal_log_err...')\n#2 /var/www/journal-cms/vendor/drush/drush/includes/command.inc(231): _drush_invoke_hooks(Array, Array)\n#3 /var/www/journal-cms/vendor/drush/drush/includes/command.inc(199): drush_command('_drupal_log_err...')\n#4 /var/www/journal-cms/vendor/drush/drush/lib/Drush/Boot/BaseBoot.php(67): drush_dispatch(Array)\n#5 /var/www/journal-cms/vendor/drush/drush/includes/preflight.inc(66): Drush\\Boot\\BaseBoot->bootstrap_and_dispatch()\n#6 /var/www/journal-cms/vendor/drush/drush/drush.php(12): drush_main()\n#7 {main}"} {"memory_usage":"36 MB","referer":"","ip":"127.0.0.1","request_uri":"http://default/","uid":"0","user":""}
```

The filename could be something like: `private://monolog/default-YYYY-MM-DD.log` or simply `private://monolog/default.log`.

And we can determine in each environment where we want to write the logs and if you want to split different log channels into different files.

In order to configure it we need to setup an environment specific `services.yml` file in the `web/sites/default` folder.

An example of the settings:

```
parameters:
  monolog.channel_handlers:
    default: ['default_handler']
  monolog.processors: ['message_placeholder', 'current_user', 'request_uri', 'ip', 'referer', 'memory_usage']

services:
  monolog.handler.default_handler:
    class: Monolog\Handler\RotatingFileHandler
    arguments: ['private://monolog/default.log', 10]
```

If you wish to use the Drupal private folder then it must be set in each environment in the `config/local.settings.php` file.

Like:
```
$settings['file_private_path'] = '/srv/journal/private';
```

The version of `monolog/monolog` is the `1.22.1` and the version of `symfony/yaml` is `2.8.19`.

It should be possible to configure this to be like:

https://github.com/elifesciences/logging-sdk-php/blob/master/src/LoggingFactory.php