### PR TITLE
Ensure fragment api request is only made when article amend in admin UI

### DIFF
--- a/src/modules/jcms_article/jcms_article.module
+++ b/src/modules/jcms_article/jcms_article.module
@@ -5,6 +5,7 @@
  * Contains jcms_article.module..
  */
 
+use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\Entity\EntityInterface;
 
@@ -35,10 +36,52 @@ function jcms_article_node_presave(EntityInterface $entity) {
   if (!empty($entity->migration)) {
     $node_presave->forMigrationOnly();
   }
+
+  $admin_ui = _jcms_admin_static_store('node_article_form_admin_ui');
+
+  // Only post to the fragmentApi if article node was saved in the admin UI.
+  if (!empty($admin_ui)) {
+    $node_presave->updateFragmentApi($entity, $entity->label());
+  }
+
+  // @todo - elife - nlisgo - Ensure we're not requesting in ArticleCrud and here.
   $article = $node_presave->getArticleById($entity->label());
-  $node_presave->updateFragmentApi($entity, $article);
-  $node_presave->addJsonFields($entity, $article);
-  $node_presave->setPublishedStatus($entity, $article);
-  $node_presave->setStatusDate($entity, $article);
-  $node_presave->setSubjectTerms($entity, $article);
+
+  // Only update the Json fields in admin UI if the node is new.
+  if (!empty($admin_ui) && $entity->isNew()) {
+    $node_presave->addJsonFields($entity, $article);
+  }
+
+  if (empty($admin_ui) || $entity->isNew()) {
+    $node_presave->setPublishedStatus($entity, $article);
+    $node_presave->setStatusDate($entity, $article);
+    $node_presave->setSubjectTerms($entity, $article);
+  }
+}
+
+/**
+ * Implements hook_form_alter().
+ */
+function jcms_article_form_alter(&$form, FormStateInterface $form_state, $form_id) {
+  _jcms_admin_protect_id_field($form, $form_id);
+  switch ($form_id) {
+    case 'node_article_form':
+    case 'node_article_edit_form':
+      foreach (array_keys($form['actions']) as $action) {
+        if ($action != 'preview' && isset($form['actions'][$action]['#type']) && $form['actions'][$action]['#type'] === 'submit') {
+          array_unshift($form['actions'][$action]['#submit'], '_jcms_article_form_node_article_edit_form_submit');
+        }
+      }
+      break;
+  }
+}
+
+/**
+ * Submit function for node_article_form and node_article_edit_form.
+ *
+ * @param $form
+ * @param \Drupal\Core\Form\FormStateInterface $form_state
+ */
+function _jcms_article_form_node_article_edit_form_submit($form, FormStateInterface $form_state) {
+  _jcms_admin_static_store('node_article_form_admin_ui', 1);
 }

--- a/src/modules/jcms_article/src/FragmentApi.php
+++ b/src/modules/jcms_article/src/FragmentApi.php
@@ -49,6 +49,12 @@ class FragmentApi {
       'http_errors' => FALSE,
     ]);
 
+    \Drupal::logger('jcms_article')
+      ->notice(
+        'An image fragment has been posted to @endpoint with the response: @response',
+        ['@endpoint' => $endpoint, '@response' => \GuzzleHttp\Psr7\str($response)]
+      );
+
     if ($response->getStatusCode() !== Response::HTTP_OK) {
       throw new \Exception("Fragment API update could not be performed.");
     }
@@ -73,6 +79,12 @@ class FragmentApi {
       ],
       'http_errors' => FALSE,
     ]);
+
+    \Drupal::logger('jcms_article')
+      ->notice(
+        'An image fragment has been deleted at @endpoint with the response: @response',
+        ['@endpoint' => $endpoint, '@response' => \GuzzleHttp\Psr7\str($response)]
+      );
 
     if (!in_array($response->getStatusCode(), [Response::HTTP_OK, Response::HTTP_NOT_FOUND])) {
       throw new \Exception("Fragment API delete could not be performed.");

--- a/src/modules/jcms_article/src/Hooks/NodePresave.php
+++ b/src/modules/jcms_article/src/Hooks/NodePresave.php
@@ -135,20 +135,19 @@ final class NodePresave {
    * Update or delete the article fragment.
    *
    * @param \Drupal\Core\Entity\EntityInterface $entity
-   * @param \Drupal\jcms_article\Entity\ArticleVersions $article
+   * @param string $articleId
    */
-  public function updateFragmentApi(EntityInterface $entity, ArticleVersions $article) {
+  public function updateFragmentApi(EntityInterface $entity, string $articleId) {
     if (empty(Settings::get('jcms_article_auth_unpublished', FALSE))) {
       return;
     }
 
     if ($image = $this->processFieldImage($entity->get('field_image'), FALSE, 'thumbnail')) {
-      $this->fragmentApi->postImageFragment($article->getId(), json_encode(['image' => $image]));
+      $this->fragmentApi->postImageFragment($articleId, json_encode(['image' => $image]));
     }
     else {
-      $this->fragmentApi->deleteImageFragment($article->getId());
+      $this->fragmentApi->deleteImageFragment($articleId);
     }
-    // $entity->set('field_article_json', NULL);
   }
 
   /**


### PR DESCRIPTION
Improve logging of requests to fragment api
Only write data retrievable from lax when node is new or modified programmatically

If we don't do this then posting a fragment or saving article metrics could cause an endless loop of requests to lax and posts to the fragment api.