### PR TITLE
Monitor exceptions

### DIFF
--- a/src/modules/jcms_rest/jcms_rest.services.yml
+++ b/src/modules/jcms_rest/jcms_rest.services.yml
@@ -7,6 +7,11 @@ services:
     class: Drupal\jcms_rest\EventSubscriber\ExceptionJcmsJsonSubscriber
     tags:
       - { name: event_subscriber }
+  jcms_rest.exception.monitoring:
+    class: Drupal\jcms_rest\EventSubscriber\MonitoringSubscriber
+    arguments: ["@jcms_rest.monitoring"]
+    tags:
+      - { name: event_subscriber }
   jcms_rest.route_subscriber:
     class: Drupal\jcms_rest\Routing\RouteSubscriber
     tags:
@@ -18,4 +23,6 @@ services:
       - { name: route_filter }
   jcms_rest.path_media_type_mapper:
     class: Drupal\jcms_rest\PathMediaTypeMapper
+  jcms_rest.monitoring:
+    class: eLife\Logging\Monitoring
 

--- a/src/modules/jcms_rest/src/EventSubscriber/MonitoringSubscriber.php
+++ b/src/modules/jcms_rest/src/EventSubscriber/MonitoringSubscriber.php
@@ -1,0 +1,44 @@
+<?php
+namespace Drupal\jcms_rest\EventSubscriber;
+
+use Drupal\Core\Utility\Error;
+use eLife\Logging\Monitoring;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
+use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * Records exceptions for monitoring.
+ */
+class MonitoringSubscriber implements EventSubscriberInterface {
+
+  /**
+   * @var \eLife\Logging\Monitoring
+   */
+  private $monitoring;
+
+  public function __construct(Monitoring $monitoring) {
+    $this->monitoring = $monitoring;
+  }
+
+  /**
+   * Log all exceptions.
+   *
+   * @param \Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent $event
+   *   The event to process.
+   */
+  public function onException(GetResponseForExceptionEvent $event) {
+    $exception = $event->getException();
+
+    $this->monitoring->recordException($exception);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents() {
+    $events[KernelEvents::EXCEPTION][] = ['onException', 50];
+    return $events;
+  }
+}


### PR DESCRIPTION
There are already logging subscribers that append controller exceptions to the Monolog error.json file and to the PHP error log. This adds the exception to New Relic, where it will be counted in the Error Rate and possibly trigger email alerts.