### PR TITLE
Using HTTPS in smoke tests

### DIFF
--- a/smoke_tests.sh
+++ b/smoke_tests.sh
@@ -2,7 +2,12 @@
 set -ex
 
 local_hostname=$(hostname)
-hostname=${1:-$local_hostname}
+if [ "$ENVIRONMENT_NAME" != "dev" ]; then
+    scheme='https'
+else
+    scheme='http'
+fi
+hostname="${scheme}://${1:-$local_hostname}"
 
 echo "Ping"
 [ $(curl --write-out %{http_code} --silent --output /dev/null "${hostname}/ping") == 200 ]


### PR DESCRIPTION
Recently (today) the upgrade from HTTP to HTTPS started working, so these URLs when loaded in HTTP will get a 301 redirect to their HTTPS equivalent.

Still, locally or if no ENVIRONMENT_NAME is specified (other VMs), we leave the possibility to use HTTP.