### PR TITLE
ELPP-2542 Introduce attribution property to image

### DIFF
--- a/src/modules/jcms_rest/src/Plugin/rest/resource/AbstractRestResourceBase.php
+++ b/src/modules/jcms_rest/src/Plugin/rest/resource/AbstractRestResourceBase.php
@@ -208,7 +208,9 @@ abstract class AbstractRestResourceBase extends ResourceBase {
                 }
               }
               if ($content_item->get('field_block_attribution')->count()) {
-                $result_item['attribution'] = array_values(array_filter(preg_split("(\r\n?|\n)", $content_item->get('field_block_attribution')->getString())));
+                $result_item['image']['attribution'] = array_values(array_filter(preg_split("(\r\n?|\n)", $content_item->get('field_block_attribution')->getString())));
+                // @todo - elife - nlisgo - remove support for this when no longer used in journal.
+                $result_item['attribution'] = $result_item['image']['attribution'];
               }
               $result_item = $this->processFigure($result_item, $content_item, $asset_ids[$content_type]);
             }


### PR DESCRIPTION
`journal-cms` currently only supports attribution in the content block. This interim solution should ensure that `journal` can switch to using the new structure, after which we can drop support for `attribution` as a sibling to `image`.