### PR TITLE
Fix inline image blocks

### DIFF
--- a/src/modules/jcms_rest/src/Plugin/rest/resource/AbstractRestResourceBase.php
+++ b/src/modules/jcms_rest/src/Plugin/rest/resource/AbstractRestResourceBase.php
@@ -298,7 +298,7 @@ abstract class AbstractRestResourceBase extends ResourceBase {
         'assets' => [['id' => $asset_id, 'label' => $content_item->get('field_block_label')->getString()] + $data],
       ];
     }
-    elseif ($content_item->get('field_block_image_inline')->getValue()) {
+    elseif ($content_item->hasField('field_block_image_inline') && $content_item->get('field_block_image_inline')->getValue()) {
       $data['inline'] = TRUE;
     }
     return $data;

--- a/src/modules/jcms_rest/src/Plugin/rest/resource/AbstractRestResourceBase.php
+++ b/src/modules/jcms_rest/src/Plugin/rest/resource/AbstractRestResourceBase.php
@@ -298,7 +298,7 @@ abstract class AbstractRestResourceBase extends ResourceBase {
         'assets' => [['id' => $asset_id, 'label' => $content_item->get('field_block_label')->getString()] + $data],
       ];
     }
-    elseif ($content_item->hasField('field_block_image_inline') && $content_item->get('field_block_image_inline')->getValue()) {
+    elseif ($content_item->hasField('field_block_image_inline') && !!$content_item->get('field_block_image_inline')->getString()) {
       $data['inline'] = TRUE;
     }
     return $data;


### PR DESCRIPTION
There's currently a problem where the `field_block_image_inline` field doesn't exists. This clearly is a bigger issue, but we can unbreak API responses by checking for it.