### PR TITLE
Make sure the whole response body is read

### DIFF
--- a/src/modules/jcms_article/src/FetchArticle.php
+++ b/src/modules/jcms_article/src/FetchArticle.php
@@ -53,9 +53,7 @@ class FetchArticle {
    */
   public function getArticleById(string $id): Article {
     $response = $this->requestArticle($id);
-    // This will almost always be a string but in case it's null or something.
-    $json = $response->getBody()->getContents() ?: '';
-    return new Article($id, $json);
+    return new Article($id, (string) $response->getBody());
   }
 
   /**
@@ -118,8 +116,7 @@ class FetchArticle {
       while (!$stop) {
         $response = $this->client->get($endpoint, $options + ['query' => ['per-page' => $per_page, 'page' => $page]]);
         if ($response instanceof ResponseInterface) {
-          $body = $response->getBody()->getContents();
-          $json = json_decode($body, TRUE);
+          $json = json_decode((string) $response->getBody(), TRUE);
           if (isset($json['items']) && !empty($json['items'])) {
             foreach ($json['items'] as $data) {
               if (isset($data['id'])) {

--- a/src/modules/jcms_article/src/FetchArticleMetrics.php
+++ b/src/modules/jcms_article/src/FetchArticleMetrics.php
@@ -57,8 +57,7 @@ final class FetchArticleMetrics {
    */
   public function getArticleMetrics(string $id): ArticleMetrics {
     $response = $this->requestArticleMetrics($id);
-    // This will almost always be a string but in case it's null or something.
-    $json = json_decode($response->getBody()->getContents() ?: '{}', TRUE);
+    $json = json_decode((string) $response->getBody(), TRUE);
     if ($response->getStatusCode() == Response::HTTP_NOT_FOUND) {
       return new ArticleMetrics($id, 0);
     }

--- a/src/modules/jcms_article/src/FetchArticleVersions.php
+++ b/src/modules/jcms_article/src/FetchArticleVersions.php
@@ -57,8 +57,7 @@ final class FetchArticleVersions {
     $response = $this->requestArticleVersions($id);
     $action = $response->getStatusCode() == 404 ? ArticleVersions::DELETE : ArticleVersions::WRITE;
     // This will almost always be a string but in case it's null or something.
-    $json = $response->getBody()->getContents() ?: '';
-    return new ArticleVersions($id, $json, $action);
+    return new ArticleVersions($id, (string) $response->getBody(), $action);
   }
 
   /**

--- a/src/modules/jcms_migrate/src/Plugin/migrate/process/JCMSGetRemoteFileTrait.php
+++ b/src/modules/jcms_migrate/src/Plugin/migrate/process/JCMSGetRemoteFileTrait.php
@@ -15,7 +15,7 @@ trait JCMSGetRemoteFileTrait {
       ];
       $response = $guzzle->get($filename, $options);
       if ($response->getStatusCode() == 200) {
-        return $response->getBody()->getContents();
+        return (string) $response->getBody();
       }
 
       error_log(sprintf("File %s didn't download. (return code %d)", $filename, $response->getStatusCode()));

--- a/src/modules/jcms_rest/tests/src/Functional/RamlSchemaValidationTest.php
+++ b/src/modules/jcms_rest/tests/src/Functional/RamlSchemaValidationTest.php
@@ -139,7 +139,7 @@ class RamlSchemaValidationTest extends UnitTestCase {
       shell_exec("$script >/dev/null 2>&1");
     }
     $list_response = $this->makeGuzzleRequest($http_method, $endpoint, $media_type_list);
-    $data = json_decode($list_response->getBody()->getContents());
+    $data = json_decode((string) $list_response->getBody());
     $this->validator->validate($list_response);
     $this->assertEquals(200, $list_response->getStatusCode());
     // To be added when generating content for all items in the data provider.

--- a/src/modules/jcms_rest/tests/src/Functional/RecursiveEndpointValidatorTest.php
+++ b/src/modules/jcms_rest/tests/src/Functional/RecursiveEndpointValidatorTest.php
@@ -191,7 +191,7 @@ class RecursiveEndpointValidatorTest extends UnitTestCase {
       ]);
 
       $response = $this->client->send($request);
-      $data = \GuzzleHttp\json_decode($response->getBody()->getContents());
+      $data = \GuzzleHttp\json_decode((string) $response->getBody());
       $this->validator->validate($response);
 
       $items = isset($data->items) ? $data->items : $data;

--- a/src/modules/jcms_rest/tests/src/Functional/UnrecognisedAcceptHeaderTest.php
+++ b/src/modules/jcms_rest/tests/src/Functional/UnrecognisedAcceptHeaderTest.php
@@ -151,7 +151,7 @@ class UnrecognisedAcceptHeaderTest extends UnitTestCase {
         $this->assertEquals($expected_content_type[0], $response->getHeaderLine('Content-Type'));
       }
       if (!is_null($id_key)) {
-        $data = \GuzzleHttp\json_decode($response->getBody()->getContents());
+        $data = \GuzzleHttp\json_decode((string) $response->getBody());
         if (!empty($data->items)) {
           $item = reset($data->items);
           $request = new Request('GET', $endpoint . '/' . $item->{$id_key}, $headers);

--- a/src/modules/jcms_rest/tests/src/Functional/UnsupportedEndpointValidatorTest.php
+++ b/src/modules/jcms_rest/tests/src/Functional/UnsupportedEndpointValidatorTest.php
@@ -44,7 +44,7 @@ class UnsupportedEndpointValidatorTest extends RecursiveEndpointValidatorTest {
       $this->assertContains($response->getStatusCode(), [Response::HTTP_OK, Response::HTTP_NOT_ACCEPTABLE]);
 
       if ($response->getStatusCode() == Response::HTTP_NOT_ACCEPTABLE) {
-        $body = \GuzzleHttp\json_decode($response->getBody()->getContents());
+        $body = \GuzzleHttp\json_decode((string) $response->getBody());
         $this->assertEquals($check, $body->title);
         $this->validator->validate($response);
       }


### PR DESCRIPTION
`StreamInterface::getContents()` returns the _remaining contents_. We always want the whole thing (incase the stream has already been read).