### PR TITLE
Add processed field to improve API performance

### DIFF
--- a/src/modules/jcms_rest/jcms_rest.install
+++ b/src/modules/jcms_rest/jcms_rest.install
@@ -25,3 +25,42 @@ function jcms_rest_update_8101() {
     }
   }
 }
+
+/**
+ * Resave all nodes that need to presave processed output
+ */
+function jcms_rest_update_8102(&$sandbox) {
+  
+  if (!isset($sandbox['progress'])) {
+    // This must be the first run. Initialize the sandbox.
+    $sandbox['progress'] = 0;
+    $sandbox['current_pk'] = 0;
+    $query = \Drupal::entityQuery('node')
+      ->condition('type', ['blog_article', 'event', 'interview', 'press_package', 'labs_experiment', 'person'], 'IN');
+    $sandbox['max'] = $query->count()->execute() - 1;
+  }
+  
+  // Update 20 nodes at a time.
+  $query = \Drupal::entityQuery('node')
+    ->condition('type', ['blog_article', 'event', 'interview', 'press_package', 'labs_experiment', 'person'], 'IN')
+    ->condition('nid', $sandbox['current_pk'], '>')      
+    ->range(0, 20)
+    ->sort('nid', 'ASC');      
+  $nids = $query->execute();
+  if ($nids) {
+    $nodes = Node::loadMultiple($nids);
+    if (!empty($nodes)) {
+      foreach ($nodes as $node) {
+        $node->save();
+        $sandbox['progress']++;
+        $sandbox['current_pk'] = $node->id();
+      }
+    }
+  }
+  if (empty($sandbox['max']) ||  $sandbox['progress'] >= $sandbox['max']) {
+     $sandbox['#finished'] = TRUE;
+  }
+  else {
+    $sandbox['#finished'] = $sandbox['progress'] / $sandbox['max'];
+  }
+}

--- a/src/modules/jcms_rest/jcms_rest.module
+++ b/src/modules/jcms_rest/jcms_rest.module
@@ -1,0 +1,30 @@
+<?php
+
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Implements hook_entity_presave().
+ * 
+ * Preprocess output fields and save in field_processed_json on
+ * node to improve API performance.
+ * 
+ * @param EntityInterface $entity
+ */
+function jcms_rest_entity_presave(EntityInterface $entity) {
+  if ($entity->getEntityType()->id() == 'node'){
+    if ($entity->hasField('field_content') && $entity->hasField('field_processed_json')) {
+      $pluginManager = \Drupal::service('plugin.manager.rest');
+      $processed = $pluginManager->createInstance('blog_article_item_rest_resource', [])->processFieldContent($entity->get('field_content'));
+      $entity->field_processed_json = json_encode($processed);
+    }
+    else {
+      $bundle = $entity->getType();
+      if ($bundle == 'person' && $entity->hasField('field_processed_json')) {
+        $pluginManager = \Drupal::service('plugin.manager.rest');
+        $processed = $pluginManager->createInstance('person_item_rest_resource', [])->getItem($entity);
+        $entity->field_processed_json = json_encode($processed);
+      }
+    }
+  }
+}

--- a/src/modules/jcms_rest/src/Plugin/rest/resource/AbstractRestResourceBase.php
+++ b/src/modules/jcms_rest/src/Plugin/rest/resource/AbstractRestResourceBase.php
@@ -152,7 +152,7 @@ abstract class AbstractRestResourceBase extends ResourceBase {
    * @param bool $required
    * @return array
    */
-  protected function processFieldContent(FieldItemListInterface $data, $required = FALSE) {
+  public function processFieldContent(FieldItemListInterface $data, $required = FALSE) {
     $asset_ids = [
       'image' => 0,
       'table' => 0,

--- a/src/modules/jcms_rest/src/Plugin/rest/resource/BlogArticleItemRestResource.php
+++ b/src/modules/jcms_rest/src/Plugin/rest/resource/BlogArticleItemRestResource.php
@@ -64,8 +64,12 @@ class BlogArticleItemRestResource extends AbstractRestResourceBase {
         }
       }
 
-      if ($content = $this->processFieldContent($node->get('field_content'))) {
-        $response['content'] = $content;
+      if ($node->hasField('field_processed_json')) {
+        $processed = $node->get('field_processed_json')->getValue();
+        $response['content'] = json_decode($processed[0]['value']);
+      }
+      else {
+        throw new \Exception("Processed json field not found on entity");
       }
 
       // Subjects is optional.

--- a/src/modules/jcms_rest/src/Plugin/rest/resource/EventItemRestResource.php
+++ b/src/modules/jcms_rest/src/Plugin/rest/resource/EventItemRestResource.php
@@ -67,8 +67,14 @@ class EventItemRestResource extends AbstractRestResourceBase {
         $response['uri'] = $node->get('field_event_uri')->first()->getValue()['uri'];
       }
       // Content is optional, only display if there is no Event URI.
-      elseif ($content = $this->processFieldContent($node->get('field_content'))) {
-        $response['content'] = $content;
+      else{
+        if ($node->hasField('field_processed_json')) {
+          $processed = $node->get('field_processed_json')->getValue();
+          $response['content'] = json_decode($processed[0]['value']);
+        }
+        else {
+          throw new \Exception("Processed json field not found on entity");
+        }
       }
 
       $response = new JCMSRestResponse($response, Response::HTTP_OK, ['Content-Type' => $this->getContentType()]);

--- a/src/modules/jcms_rest/src/Plugin/rest/resource/InterviewItemRestResource.php
+++ b/src/modules/jcms_rest/src/Plugin/rest/resource/InterviewItemRestResource.php
@@ -71,8 +71,12 @@ class InterviewItemRestResource extends AbstractRestResourceBase {
         $response['image'] = $image;
       }
 
-      if ($content = $this->processFieldContent($node->get('field_content'))) {
-        $response['content'] = $content;
+      if ($node->hasField('field_processed_json')) {
+        $processed = $node->get('field_processed_json')->getValue();
+        $response['content'] = json_decode($processed[0]['value']);
+      }
+      else {
+        throw new \Exception("Processed json field not found on entity");
       }
 
       $response = new JCMSRestResponse($response, Response::HTTP_OK, ['Content-Type' => $this->getContentType()]);

--- a/src/modules/jcms_rest/src/Plugin/rest/resource/LabsExperimentItemRestResource.php
+++ b/src/modules/jcms_rest/src/Plugin/rest/resource/LabsExperimentItemRestResource.php
@@ -63,8 +63,12 @@ class LabsExperimentItemRestResource extends AbstractRestResourceBase {
         }
       }
 
-      if ($content = $this->processFieldContent($node->get('field_content'))) {
-        $response['content'] = $content;
+      if ($node->hasField('field_processed_json')) {
+        $processed = $node->get('field_processed_json')->getValue();
+        $response['content'] = json_decode($processed[0]['value']);
+      }
+      else {
+        throw new \Exception("Processed json field not found on entity");
       }
 
       $response = new JCMSRestResponse($response, Response::HTTP_OK, ['Content-Type' => $this->getContentType()]);

--- a/src/modules/jcms_rest/src/Plugin/rest/resource/PersonItemRestResource.php
+++ b/src/modules/jcms_rest/src/Plugin/rest/resource/PersonItemRestResource.php
@@ -59,7 +59,7 @@ class PersonItemRestResource extends AbstractRestResourceBase {
     if ($nids) {
       $nid = reset($nids);
       $node = Node::load($nid);
-      $item = $this->getItem($node);
+      $item = $this->getProcessedItem($node);
       $response = new JCMSRestResponse($item, Response::HTTP_OK, ['Content-Type' => $this->getContentType()]);
       $response->addCacheableDependency($node);
       return $response;
@@ -69,6 +69,24 @@ class PersonItemRestResource extends AbstractRestResourceBase {
     return FALSE;
   }
 
+  /**
+   * Takes a node and get the previously processed item from it.
+   *
+   * @param \Drupal\Core\Entity\EntityInterface $node
+   *
+   * @return array
+   */
+  public function getProcessedItem($node, $getItem = FALSE) {
+    if ($node->hasField('field_processed_json') && !$getItem) {
+      $processed = $node->get('field_processed_json')->getValue();
+      $item = json_decode($processed[0]['value']);
+    }
+    else {
+      throw new \Exception("Processed json field not found on entity");
+    }
+    return $item;
+  }
+  
   /**
    * Takes a node and builds an item from it.
    *

--- a/src/modules/jcms_rest/src/Plugin/rest/resource/PersonListRestResource.php
+++ b/src/modules/jcms_rest/src/Plugin/rest/resource/PersonListRestResource.php
@@ -57,7 +57,7 @@ class PersonListRestResource extends AbstractRestResourceBase {
       $nodes = Node::loadMultiple($nids);
       if (!empty($nodes)) {
         foreach ($nodes as $node) {
-          $response_data['items'][] = $person_item_rest_resource->getItem($node);
+          $response_data['items'][] = $person_item_rest_resource->getProcessedItem($node);
         }
       }
     }

--- a/src/modules/jcms_rest/src/Plugin/rest/resource/PressPackageItemRestResource.php
+++ b/src/modules/jcms_rest/src/Plugin/rest/resource/PressPackageItemRestResource.php
@@ -56,8 +56,12 @@ class PressPackageItemRestResource extends AbstractRestResourceBase {
         }
       }
 
-      if ($content = $this->processFieldContent($node->get('field_content'))) {
-        $response['content'] = $content;
+      if ($node->hasField('field_processed_json')) {
+        $processed = $node->get('field_processed_json')->getValue();
+        $response['content'] = json_decode($processed[0]['value']);
+      }
+      else {
+        throw new \Exception("Processed json field not found on entity");
       }
 
       if ($node->get('field_related_content')->count()) {

--- a/sync/core.entity_form_display.node.blog_article.default.yml
+++ b/sync/core.entity_form_display.node.blog_article.default.yml
@@ -9,6 +9,7 @@ dependencies:
     - field.field.node.blog_article.field_image_attribution
     - field.field.node.blog_article.field_impact_statement
     - field.field.node.blog_article.field_order_date
+    - field.field.node.blog_article.field_processed_json
     - field.field.node.blog_article.field_subjects
     - image.style.thumbnail
     - node.type.blog_article
@@ -85,6 +86,7 @@ content:
 hidden:
   created: true
   field_order_date: true
+  field_processed_json: true
   path: true
   promote: true
   sticky: true

--- a/sync/core.entity_form_display.node.event.default.yml
+++ b/sync/core.entity_form_display.node.event.default.yml
@@ -10,6 +10,7 @@ dependencies:
     - field.field.node.event.field_event_uri
     - field.field.node.event.field_impact_statement
     - field.field.node.event.field_order_date
+    - field.field.node.event.field_processed_json
     - node.type.event
   module:
     - content_moderation
@@ -80,6 +81,7 @@ content:
 hidden:
   created: true
   field_order_date: true
+  field_processed_json: true
   path: true
   promote: true
   sticky: true

--- a/sync/core.entity_form_display.node.interview.default.yml
+++ b/sync/core.entity_form_display.node.interview.default.yml
@@ -11,6 +11,7 @@ dependencies:
     - field.field.node.interview.field_order_date
     - field.field.node.interview.field_person_index_name
     - field.field.node.interview.field_person_preferred_name
+    - field.field.node.interview.field_processed_json
     - image.style.thumbnail
     - node.type.interview
   module:
@@ -97,6 +98,7 @@ content:
 hidden:
   created: true
   field_order_date: true
+  field_processed_json: true
   path: true
   promote: true
   sticky: true

--- a/sync/core.entity_form_display.node.labs_experiment.default.yml
+++ b/sync/core.entity_form_display.node.labs_experiment.default.yml
@@ -10,6 +10,7 @@ dependencies:
     - field.field.node.labs_experiment.field_image_attribution
     - field.field.node.labs_experiment.field_impact_statement
     - field.field.node.labs_experiment.field_order_date
+    - field.field.node.labs_experiment.field_processed_json
     - image.style.thumbnail
     - node.type.labs_experiment
   module:
@@ -83,6 +84,7 @@ content:
 hidden:
   created: true
   field_order_date: true
+  field_processed_json: true
   path: true
   promote: true
   sticky: true

--- a/sync/core.entity_form_display.node.person.default.yml
+++ b/sync/core.entity_form_display.node.person.default.yml
@@ -13,6 +13,7 @@ dependencies:
     - field.field.node.person.field_person_profile
     - field.field.node.person.field_person_type
     - field.field.node.person.field_person_type_label
+    - field.field.node.person.field_processed_json
     - field.field.node.person.field_research_details
     - image.style.thumbnail
     - node.type.person
@@ -126,6 +127,7 @@ content:
 hidden:
   created: true
   field_order_date: true
+  field_processed_json: true
   path: true
   promote: true
   sticky: true

--- a/sync/core.entity_form_display.node.press_package.default.yml
+++ b/sync/core.entity_form_display.node.press_package.default.yml
@@ -8,6 +8,7 @@ dependencies:
     - field.field.node.press_package.field_media_contact
     - field.field.node.press_package.field_order_date
     - field.field.node.press_package.field_press_package_about
+    - field.field.node.press_package.field_processed_json
     - field.field.node.press_package.field_related_content
     - node.type.press_package
   module:
@@ -88,6 +89,7 @@ content:
 hidden:
   created: true
   field_order_date: true
+  field_processed_json: true
   path: true
   promote: true
   sticky: true

--- a/sync/core.entity_view_display.node.blog_article.default.yml
+++ b/sync/core.entity_view_display.node.blog_article.default.yml
@@ -9,6 +9,7 @@ dependencies:
     - field.field.node.blog_article.field_image_attribution
     - field.field.node.blog_article.field_impact_statement
     - field.field.node.blog_article.field_order_date
+    - field.field.node.blog_article.field_processed_json
     - field.field.node.blog_article.field_subjects
     - node.type.blog_article
   module:
@@ -72,6 +73,13 @@ content:
       timezone: ''
     third_party_settings: {  }
     type: timestamp
+    region: content
+  field_processed_json:
+    weight: 8
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    type: basic_string
     region: content
   field_subjects:
     weight: 5

--- a/sync/core.entity_view_display.node.event.default.yml
+++ b/sync/core.entity_view_display.node.event.default.yml
@@ -10,6 +10,7 @@ dependencies:
     - field.field.node.event.field_event_uri
     - field.field.node.event.field_impact_statement
     - field.field.node.event.field_order_date
+    - field.field.node.event.field_processed_json
     - node.type.event
   module:
     - datetime_range
@@ -87,6 +88,13 @@ content:
       timezone: ''
     third_party_settings: {  }
     type: timestamp
+    region: content
+  field_processed_json:
+    weight: 110
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    type: basic_string
     region: content
   links:
     weight: 100

--- a/sync/core.entity_view_display.node.interview.default.yml
+++ b/sync/core.entity_view_display.node.interview.default.yml
@@ -11,6 +11,7 @@ dependencies:
     - field.field.node.interview.field_order_date
     - field.field.node.interview.field_person_index_name
     - field.field.node.interview.field_person_preferred_name
+    - field.field.node.interview.field_processed_json
     - node.type.interview
   module:
     - entity_reference_revisions
@@ -91,6 +92,13 @@ content:
       link_to_entity: false
     third_party_settings: {  }
     type: string
+    region: content
+  field_processed_json:
+    weight: 109
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    type: basic_string
     region: content
   links:
     weight: 100

--- a/sync/core.entity_view_display.node.labs_experiment.default.yml
+++ b/sync/core.entity_view_display.node.labs_experiment.default.yml
@@ -10,6 +10,7 @@ dependencies:
     - field.field.node.labs_experiment.field_image_attribution
     - field.field.node.labs_experiment.field_impact_statement
     - field.field.node.labs_experiment.field_order_date
+    - field.field.node.labs_experiment.field_processed_json
     - node.type.labs_experiment
   module:
     - entity_reference_revisions
@@ -81,6 +82,13 @@ content:
       timezone: ''
     third_party_settings: {  }
     type: timestamp
+    region: content
+  field_processed_json:
+    weight: 8
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    type: basic_string
     region: content
   links:
     weight: 0

--- a/sync/core.entity_view_display.node.person.default.yml
+++ b/sync/core.entity_view_display.node.person.default.yml
@@ -13,6 +13,7 @@ dependencies:
     - field.field.node.person.field_person_profile
     - field.field.node.person.field_person_type
     - field.field.node.person.field_person_type_label
+    - field.field.node.person.field_processed_json
     - field.field.node.person.field_research_details
     - node.type.person
   module:
@@ -110,6 +111,13 @@ content:
       link_to_entity: false
     third_party_settings: {  }
     type: string
+    region: content
+  field_processed_json:
+    weight: 113
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    type: basic_string
     region: content
   field_research_details:
     type: entity_reference_revisions_entity_view

--- a/sync/core.entity_view_display.node.press_package.default.yml
+++ b/sync/core.entity_view_display.node.press_package.default.yml
@@ -8,6 +8,7 @@ dependencies:
     - field.field.node.press_package.field_media_contact
     - field.field.node.press_package.field_order_date
     - field.field.node.press_package.field_press_package_about
+    - field.field.node.press_package.field_processed_json
     - field.field.node.press_package.field_related_content
     - node.type.press_package
   module:
@@ -62,6 +63,13 @@ content:
       view_mode: default
       link: ''
     third_party_settings: {  }
+    region: content
+  field_processed_json:
+    weight: 107
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    type: basic_string
     region: content
   field_related_content:
     weight: 103

--- a/sync/core.extension.yml
+++ b/sync/core.extension.yml
@@ -18,7 +18,6 @@ module:
   datetime_range: 0
   devel_generate: 0
   diff: 0
-  dynamic_page_cache: 0
   editor: 0
   entity_reference: 0
   entity_reference_revisions: 0
@@ -50,7 +49,6 @@ module:
   monolog: 0
   node: 0
   options: 0
-  page_cache: 0
   paragraphs: 0
   path: 0
   quickedit: 0

--- a/sync/field.field.node.blog_article.field_processed_json.yml
+++ b/sync/field.field.node.blog_article.field_processed_json.yml
@@ -1,0 +1,19 @@
+uuid: 462aed77-d58f-465c-8d24-516c6480663d
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_processed_json
+    - node.type.blog_article
+id: node.blog_article.field_processed_json
+field_name: field_processed_json
+entity_type: node
+bundle: blog_article
+label: 'Processed (JSON)'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string_long

--- a/sync/field.field.node.event.field_processed_json.yml
+++ b/sync/field.field.node.event.field_processed_json.yml
@@ -1,0 +1,19 @@
+uuid: 57435f2b-6e19-43ca-9ccf-7cc422502720
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_processed_json
+    - node.type.event
+id: node.event.field_processed_json
+field_name: field_processed_json
+entity_type: node
+bundle: event
+label: 'Processed (JSON)'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string_long

--- a/sync/field.field.node.interview.field_processed_json.yml
+++ b/sync/field.field.node.interview.field_processed_json.yml
@@ -1,0 +1,19 @@
+uuid: 39424a2f-e174-4b90-b387-c91395a99f31
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_processed_json
+    - node.type.interview
+id: node.interview.field_processed_json
+field_name: field_processed_json
+entity_type: node
+bundle: interview
+label: 'Processed (JSON)'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string_long

--- a/sync/field.field.node.labs_experiment.field_processed_json.yml
+++ b/sync/field.field.node.labs_experiment.field_processed_json.yml
@@ -1,0 +1,19 @@
+uuid: bdfe8638-ad7a-4ea1-9cad-0f05e129173f
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_processed_json
+    - node.type.labs_experiment
+id: node.labs_experiment.field_processed_json
+field_name: field_processed_json
+entity_type: node
+bundle: labs_experiment
+label: 'Processed (JSON)'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string_long

--- a/sync/field.field.node.person.field_processed_json.yml
+++ b/sync/field.field.node.person.field_processed_json.yml
@@ -1,0 +1,19 @@
+uuid: eabc907c-366d-4f8a-bdc8-5a13816c6754
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_processed_json
+    - node.type.person
+id: node.person.field_processed_json
+field_name: field_processed_json
+entity_type: node
+bundle: person
+label: 'Processed (JSON)'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string_long

--- a/sync/field.field.node.press_package.field_processed_json.yml
+++ b/sync/field.field.node.press_package.field_processed_json.yml
@@ -1,0 +1,19 @@
+uuid: 88bba60e-d17d-44b9-8a73-814060642c83
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_processed_json
+    - node.type.press_package
+id: node.press_package.field_processed_json
+field_name: field_processed_json
+entity_type: node
+bundle: press_package
+label: 'Processed (JSON)'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string_long


### PR DESCRIPTION
A new field called field_processed_json has been added to six content types that is used to store static content for each node. This field is populated by a preprocessor using hook_entity_presave. Once populated the processed output is available for rendering the API response making the API response build time much faster.

The affected content types are blog_article, event, interview, labs_experiment and press_package where the paragraph field field_content is processed and stored in field_processed_json. The other content type affected is person where the paragraph fields field_person_profile, field_research_details and field_person_affiliation are processed and stored in field_processed_json.

An update hook is provided to resave all affected nodes that causes the preprocessor to run and populate the new field.