### PR TITLE
Hide moderation status field

### DIFF
--- a/sync/core.entity_form_display.block_content.basic.default.yml
+++ b/sync/core.entity_form_display.block_content.basic.default.yml
@@ -31,4 +31,5 @@ content:
       placeholder: ''
     third_party_settings: {  }
     region: content
-hidden: {  }
+hidden:
+  moderation_state: true

--- a/sync/core.entity_form_display.node.annual_report.default.yml
+++ b/sync/core.entity_form_display.node.annual_report.default.yml
@@ -59,19 +59,11 @@ content:
     third_party_settings: {  }
     type: link_default
     region: content
-  moderation_state:
-    weight: 122
-    settings:
-      size: 60
-      placeholder: ''
-    third_party_settings: {  }
-    type: string_textfield
-    region: content
   status:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 121
+    weight: 6
     third_party_settings: {  }
     region: content
   title:
@@ -85,6 +77,7 @@ content:
 hidden:
   created: true
   field_order_date: true
+  moderation_state: true
   path: true
   promote: true
   sticky: true

--- a/sync/core.entity_form_display.node.article.default.yml
+++ b/sync/core.entity_form_display.node.article.default.yml
@@ -40,19 +40,11 @@ content:
     third_party_settings: {  }
     type: number
     region: content
-  moderation_state:
-    weight: 122
-    settings:
-      size: 60
-      placeholder: ''
-    third_party_settings: {  }
-    type: string_textfield
-    region: content
   status:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 121
+    weight: 4
     third_party_settings: {  }
     region: content
   title:
@@ -68,6 +60,7 @@ hidden:
   field_article_json: true
   field_order_date: true
   field_subjects: true
+  moderation_state: true
   path: true
   promote: true
   sticky: true

--- a/sync/core.entity_form_display.node.blog_article.default.yml
+++ b/sync/core.entity_form_display.node.blog_article.default.yml
@@ -74,19 +74,11 @@ content:
     third_party_settings: {  }
     type: entity_reference_autocomplete
     region: content
-  moderation_state:
-    weight: 122
-    settings:
-      size: 60
-      placeholder: ''
-    third_party_settings: {  }
-    type: string_textfield
-    region: content
   status:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 121
+    weight: 7
     third_party_settings: {  }
     region: content
   title:
@@ -101,6 +93,7 @@ hidden:
   created: true
   field_content_processed_json: true
   field_order_date: true
+  moderation_state: true
   path: true
   promote: true
   sticky: true

--- a/sync/core.entity_form_display.node.collection.default.yml
+++ b/sync/core.entity_form_display.node.collection.default.yml
@@ -122,19 +122,11 @@ content:
       default_paragraph_type: paragraph
     third_party_settings: {  }
     region: content
-  moderation_state:
-    weight: 122
-    settings:
-      size: 60
-      placeholder: ''
-    third_party_settings: {  }
-    type: string_textfield
-    region: content
   status:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 121
+    weight: 11
     third_party_settings: {  }
     region: content
   title:
@@ -148,6 +140,7 @@ content:
 hidden:
   created: true
   field_order_date: true
+  moderation_state: true
   path: true
   promote: true
   sticky: true

--- a/sync/core.entity_form_display.node.event.default.yml
+++ b/sync/core.entity_form_display.node.event.default.yml
@@ -69,19 +69,11 @@ content:
     third_party_settings: {  }
     type: text_textarea
     region: content
-  moderation_state:
-    weight: 122
-    settings:
-      size: 60
-      placeholder: ''
-    third_party_settings: {  }
-    type: string_textfield
-    region: content
   status:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 121
+    weight: 7
     third_party_settings: {  }
     region: content
   title:
@@ -96,6 +88,7 @@ hidden:
   created: true
   field_content_processed_json: true
   field_order_date: true
+  moderation_state: true
   path: true
   promote: true
   sticky: true

--- a/sync/core.entity_form_display.node.highlight_item.default.yml
+++ b/sync/core.entity_form_display.node.highlight_item.default.yml
@@ -32,19 +32,11 @@ content:
     third_party_settings: {  }
     type: image_image
     region: content
-  moderation_state:
-    weight: 122
-    settings:
-      size: 60
-      placeholder: ''
-    third_party_settings: {  }
-    type: string_textfield
-    region: content
   status:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 121
+    weight: 3
     third_party_settings: {  }
     region: content
   title:
@@ -58,6 +50,7 @@ content:
 hidden:
   created: true
   field_order_date: true
+  moderation_state: true
   path: true
   promote: true
   sticky: true

--- a/sync/core.entity_form_display.node.highlight_list.default.yml
+++ b/sync/core.entity_form_display.node.highlight_list.default.yml
@@ -26,19 +26,11 @@ content:
     third_party_settings: {  }
     type: inline_entity_form_complex
     region: content
-  moderation_state:
-    weight: 122
-    settings:
-      size: 60
-      placeholder: ''
-    third_party_settings: {  }
-    type: string_textfield
-    region: content
   status:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 121
+    weight: 2
     third_party_settings: {  }
     region: content
   title:
@@ -52,6 +44,7 @@ content:
 hidden:
   created: true
   field_order_date: true
+  moderation_state: true
   path: true
   promote: true
   sticky: true

--- a/sync/core.entity_form_display.node.interview.default.yml
+++ b/sync/core.entity_form_display.node.interview.default.yml
@@ -86,19 +86,11 @@ content:
     third_party_settings: {  }
     type: string_textfield
     region: content
-  moderation_state:
-    weight: 122
-    settings:
-      size: 60
-      placeholder: ''
-    third_party_settings: {  }
-    type: string_textfield
-    region: content
   status:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 121
+    weight: 8
     third_party_settings: {  }
     region: content
   title:
@@ -113,6 +105,7 @@ hidden:
   created: true
   field_content_processed_json: true
   field_order_date: true
+  moderation_state: true
   path: true
   promote: true
   sticky: true

--- a/sync/core.entity_form_display.node.job_advert.default.yml
+++ b/sync/core.entity_form_display.node.job_advert.default.yml
@@ -64,19 +64,11 @@ content:
     third_party_settings: {  }
     type: text_textarea
     region: content
-  moderation_state:
-    weight: 122
-    settings:
-      size: 60
-      placeholder: ''
-    third_party_settings: {  }
-    type: string_textfield
-    region: content
   status:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 121
+    weight: 7
     third_party_settings: {  }
     region: content
   title:
@@ -90,6 +82,7 @@ content:
 hidden:
   created: true
   field_order_date: true
+  moderation_state: true
   path: true
   promote: true
   sticky: true

--- a/sync/core.entity_form_display.node.labs_experiment.default.yml
+++ b/sync/core.entity_form_display.node.labs_experiment.default.yml
@@ -72,19 +72,11 @@ content:
     third_party_settings: {  }
     type: text_textarea
     region: content
-  moderation_state:
-    weight: 122
-    settings:
-      size: 60
-      placeholder: ''
-    third_party_settings: {  }
-    type: string_textfield
-    region: content
   status:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 121
+    weight: 7
     third_party_settings: {  }
     region: content
   title:
@@ -99,6 +91,7 @@ hidden:
   created: true
   field_content_processed_json: true
   field_order_date: true
+  moderation_state: true
   path: true
   promote: true
   sticky: true

--- a/sync/core.entity_form_display.node.person.default.yml
+++ b/sync/core.entity_form_display.node.person.default.yml
@@ -117,19 +117,11 @@ content:
       default_paragraph_type: ''
     third_party_settings: {  }
     region: content
-  moderation_state:
-    weight: 122
-    settings:
-      size: 60
-      placeholder: ''
-    third_party_settings: {  }
-    type: string_textfield
-    region: content
   status:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 121
+    weight: 11
     third_party_settings: {  }
     region: content
   title:
@@ -146,6 +138,7 @@ hidden:
   field_person_affiliation_json: true
   field_person_profile_json: true
   field_research_details_json: true
+  moderation_state: true
   path: true
   promote: true
   sticky: true

--- a/sync/core.entity_form_display.node.podcast_chapter.default.yml
+++ b/sync/core.entity_form_display.node.podcast_chapter.default.yml
@@ -48,19 +48,11 @@ content:
     third_party_settings: {  }
     type: entity_reference_autocomplete
     region: content
-  moderation_state:
-    weight: 122
-    settings:
-      size: 60
-      placeholder: ''
-    third_party_settings: {  }
-    type: string_textfield
-    region: content
   status:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 121
+    weight: 5
     third_party_settings: {  }
     region: content
   title:
@@ -74,6 +66,7 @@ content:
 hidden:
   created: true
   field_order_date: true
+  moderation_state: true
   path: true
   promote: true
   sticky: true

--- a/sync/core.entity_form_display.node.podcast_episode.default.yml
+++ b/sync/core.entity_form_display.node.podcast_episode.default.yml
@@ -92,19 +92,11 @@ content:
     third_party_settings: {  }
     type: entity_reference_autocomplete
     region: content
-  moderation_state:
-    weight: 122
-    settings:
-      size: 60
-      placeholder: ''
-    third_party_settings: {  }
-    type: string_textfield
-    region: content
   status:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 121
+    weight: 9
     third_party_settings: {  }
     region: content
   title:
@@ -119,6 +111,7 @@ hidden:
   created: true
   field_episode_chapters: true
   field_order_date: true
+  moderation_state: true
   path: true
   promote: true
   sticky: true

--- a/sync/core.entity_form_display.node.press_package.default.yml
+++ b/sync/core.entity_form_display.node.press_package.default.yml
@@ -77,19 +77,11 @@ content:
     third_party_settings: {  }
     type: inline_entity_form_complex
     region: content
-  moderation_state:
-    weight: 122
-    settings:
-      size: 60
-      placeholder: ''
-    third_party_settings: {  }
-    type: string_textfield
-    region: content
   status:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 121
+    weight: 6
     third_party_settings: {  }
     region: content
   title:
@@ -104,6 +96,7 @@ hidden:
   created: true
   field_content_processed_json: true
   field_order_date: true
+  moderation_state: true
   path: true
   promote: true
   sticky: true

--- a/sync/core.entity_form_display.paragraph.affiliation.default.yml
+++ b/sync/core.entity_form_display.paragraph.affiliation.default.yml
@@ -14,26 +14,21 @@ bundle: affiliation
 mode: default
 content:
   field_block_country:
-    weight: 7
+    weight: 1
     settings: {  }
     third_party_settings: {  }
     type: country_default
     region: content
   field_block_title_multiline:
-    weight: 6
+    weight: 0
     settings:
       rows: 5
       placeholder: ''
     third_party_settings: {  }
     type: string_textarea
     region: content
-  moderation_state:
-    type: moderation_state_default
-    weight: 100
-    settings: {  }
-    region: content
-    third_party_settings: {  }
 hidden:
   created: true
+  moderation_state: true
   status: true
   uid: true

--- a/sync/core.entity_form_display.paragraph.blockquote.default.yml
+++ b/sync/core.entity_form_display.paragraph.blockquote.default.yml
@@ -13,7 +13,7 @@ bundle: blockquote
 mode: default
 content:
   field_block_html:
-    weight: 2
+    weight: 0
     settings:
       rows: 5
       placeholder: ''
@@ -22,5 +22,6 @@ content:
     region: content
 hidden:
   created: true
+  moderation_state: true
   status: true
   uid: true

--- a/sync/core.entity_form_display.paragraph.button.default.yml
+++ b/sync/core.entity_form_display.paragraph.button.default.yml
@@ -13,7 +13,7 @@ bundle: button
 mode: default
 content:
   field_block_button:
-    weight: 6
+    weight: 0
     settings:
       placeholder_url: ''
       placeholder_title: ''
@@ -22,5 +22,6 @@ content:
     region: content
 hidden:
   created: true
+  moderation_state: true
   status: true
   uid: true

--- a/sync/core.entity_form_display.paragraph.code.default.yml
+++ b/sync/core.entity_form_display.paragraph.code.default.yml
@@ -20,5 +20,6 @@ content:
     region: content
 hidden:
   created: true
+  moderation_state: true
   status: true
   uid: true

--- a/sync/core.entity_form_display.paragraph.cv_item.default.yml
+++ b/sync/core.entity_form_display.paragraph.cv_item.default.yml
@@ -31,5 +31,6 @@ content:
     region: content
 hidden:
   created: true
+  moderation_state: true
   status: true
   uid: true

--- a/sync/core.entity_form_display.paragraph.image.default.yml
+++ b/sync/core.entity_form_display.paragraph.image.default.yml
@@ -52,7 +52,7 @@ content:
     type: image_image
     region: content
   field_block_image_inline:
-    weight: 6
+    weight: 5
     settings:
       display_label: true
     third_party_settings: {  }
@@ -66,13 +66,8 @@ content:
     third_party_settings: {  }
     type: string_textfield
     region: content
-  moderation_state:
-    type: moderation_state_default
-    weight: 100
-    settings: {  }
-    region: content
-    third_party_settings: {  }
 hidden:
   created: true
+  moderation_state: true
   status: true
   uid: true

--- a/sync/core.entity_form_display.paragraph.json.default.yml
+++ b/sync/core.entity_form_display.paragraph.json.default.yml
@@ -31,5 +31,6 @@ content:
     region: content
 hidden:
   created: true
+  moderation_state: true
   status: true
   uid: true

--- a/sync/core.entity_form_display.paragraph.list.default.yml
+++ b/sync/core.entity_form_display.paragraph.list.default.yml
@@ -22,6 +22,7 @@ content:
       edit_mode: open
       add_mode: dropdown
       form_display_mode: default
+      default_paragraph_type: ''
     third_party_settings: {  }
     region: content
   field_block_list_ordered:
@@ -33,5 +34,6 @@ content:
     region: content
 hidden:
   created: true
+  moderation_state: true
   status: true
   uid: true

--- a/sync/core.entity_form_display.paragraph.list_item.default.yml
+++ b/sync/core.entity_form_display.paragraph.list_item.default.yml
@@ -13,7 +13,7 @@ bundle: list_item
 mode: default
 content:
   field_block_html:
-    weight: 1
+    weight: 0
     settings:
       rows: 5
       placeholder: ''
@@ -22,5 +22,6 @@ content:
     region: content
 hidden:
   created: true
+  moderation_state: true
   status: true
   uid: true

--- a/sync/core.entity_form_display.paragraph.media_contact.default.yml
+++ b/sync/core.entity_form_display.paragraph.media_contact.default.yml
@@ -26,6 +26,7 @@ content:
       edit_mode: open
       add_mode: dropdown
       form_display_mode: default
+      default_paragraph_type: ''
     third_party_settings: {  }
     region: content
   field_block_email:
@@ -61,5 +62,6 @@ content:
     region: content
 hidden:
   created: true
+  moderation_state: true
   status: true
   uid: true

--- a/sync/core.entity_form_display.paragraph.paragraph.default.yml
+++ b/sync/core.entity_form_display.paragraph.paragraph.default.yml
@@ -13,7 +13,7 @@ bundle: paragraph
 mode: default
 content:
   field_block_html:
-    weight: 1
+    weight: 0
     settings:
       rows: 5
       placeholder: ''
@@ -22,5 +22,6 @@ content:
     region: content
 hidden:
   created: true
+  moderation_state: true
   status: true
   uid: true

--- a/sync/core.entity_form_display.paragraph.question.default.yml
+++ b/sync/core.entity_form_display.paragraph.question.default.yml
@@ -22,6 +22,7 @@ content:
       edit_mode: open
       add_mode: dropdown
       form_display_mode: default
+      default_paragraph_type: ''
     third_party_settings: {  }
     region: content
   field_block_title:
@@ -34,5 +35,6 @@ content:
     region: content
 hidden:
   created: true
+  moderation_state: true
   status: true
   uid: true

--- a/sync/core.entity_form_display.paragraph.research_details.default.yml
+++ b/sync/core.entity_form_display.paragraph.research_details.default.yml
@@ -41,5 +41,6 @@ content:
     region: content
 hidden:
   created: true
+  moderation_state: true
   status: true
   uid: true

--- a/sync/core.entity_form_display.paragraph.section.default.yml
+++ b/sync/core.entity_form_display.paragraph.section.default.yml
@@ -22,6 +22,7 @@ content:
       edit_mode: open
       add_mode: dropdown
       form_display_mode: default
+      default_paragraph_type: ''
     third_party_settings: {  }
     region: content
   field_block_title:
@@ -34,5 +35,6 @@ content:
     region: content
 hidden:
   created: true
+  moderation_state: true
   status: true
   uid: true

--- a/sync/core.entity_form_display.paragraph.venue.default.yml
+++ b/sync/core.entity_form_display.paragraph.venue.default.yml
@@ -14,14 +14,14 @@ bundle: venue
 mode: default
 content:
   field_block_address:
-    weight: 2
+    weight: 1
     settings:
       default_country: null
     third_party_settings: {  }
     type: address_default
     region: content
   field_block_title_multiline:
-    weight: 1
+    weight: 0
     settings:
       rows: 5
       placeholder: ''
@@ -30,5 +30,6 @@ content:
     region: content
 hidden:
   created: true
+  moderation_state: true
   status: true
   uid: true

--- a/sync/core.entity_form_display.paragraph.youtube.default.yml
+++ b/sync/core.entity_form_display.paragraph.youtube.default.yml
@@ -13,7 +13,7 @@ bundle: youtube
 mode: default
 content:
   field_block_youtube_id:
-    weight: 1
+    weight: 0
     settings:
       size: 60
       placeholder: ''
@@ -24,5 +24,6 @@ hidden:
   created: true
   field_block_youtube_height: true
   field_block_youtube_width: true
+  moderation_state: true
   status: true
   uid: true


### PR DESCRIPTION
This is a temporary fix until the `content_moderation` module addresses the issue of attaching the moderation status field only to appropriate content.

See: https://www.drupal.org/project/drupal/issues/2915383