### PR TITLE
Reinstate focal point widget

### DIFF
--- a/sync/core.entity_form_display.node.annual_report.default.yml
+++ b/sync/core.entity_form_display.node.annual_report.default.yml
@@ -12,7 +12,7 @@ dependencies:
     - image.style.thumbnail
     - node.type.annual_report
   module:
-    - image
+    - focal_point
     - link
     - text
 id: node.annual_report.default
@@ -40,8 +40,10 @@ content:
     settings:
       preview_image_style: thumbnail
       progress_indicator: bar
+      preview_link: true
+      offsets: '50,50'
     third_party_settings: {  }
-    type: image_image
+    type: image_focal_point
     region: content
   field_impact_statement:
     weight: 5

--- a/sync/core.entity_form_display.node.article.default.yml
+++ b/sync/core.entity_form_display.node.article.default.yml
@@ -12,7 +12,7 @@ dependencies:
     - image.style.thumbnail
     - node.type.article
   module:
-    - image
+    - focal_point
 id: node.article.default
 targetEntityType: node
 bundle: article
@@ -30,8 +30,10 @@ content:
     settings:
       progress_indicator: throbber
       preview_image_style: thumbnail
+      preview_link: true
+      offsets: '50,50'
     third_party_settings: {  }
-    type: image_image
+    type: image_focal_point
     region: content
   field_page_views:
     weight: 1

--- a/sync/core.entity_form_display.node.blog_article.default.yml
+++ b/sync/core.entity_form_display.node.blog_article.default.yml
@@ -14,7 +14,7 @@ dependencies:
     - image.style.thumbnail
     - node.type.blog_article
   module:
-    - image
+    - focal_point
     - paragraphs
     - text
 id: node.blog_article.default
@@ -46,8 +46,10 @@ content:
     settings:
       progress_indicator: throbber
       preview_image_style: thumbnail
+      preview_link: true
+      offsets: '50,50'
     third_party_settings: {  }
-    type: image_image
+    type: image_focal_point
     region: content
   field_image_attribution:
     weight: 2

--- a/sync/core.entity_form_display.node.collection.default.yml
+++ b/sync/core.entity_form_display.node.collection.default.yml
@@ -17,7 +17,7 @@ dependencies:
     - image.style.thumbnail
     - node.type.collection
   module:
-    - image
+    - focal_point
     - inline_entity_form
     - paragraphs
     - text
@@ -82,8 +82,10 @@ content:
     settings:
       progress_indicator: throbber
       preview_image_style: thumbnail
+      preview_link: true
+      offsets: '50,50'
     third_party_settings: {  }
-    type: image_image
+    type: image_focal_point
     region: content
   field_image_attribution:
     weight: 2

--- a/sync/core.entity_form_display.node.cover.default.yml
+++ b/sync/core.entity_form_display.node.cover.default.yml
@@ -11,7 +11,7 @@ dependencies:
     - node.type.cover
   module:
     - content_moderation
-    - image
+    - focal_point
     - inline_entity_form
     - text
 id: node.cover.default
@@ -37,8 +37,10 @@ content:
     settings:
       progress_indicator: throbber
       preview_image_style: thumbnail
+      preview_link: true
+      offsets: '50,50'
     third_party_settings: {  }
-    type: image_image
+    type: image_focal_point
     region: content
   field_image_attribution:
     weight: 2

--- a/sync/core.entity_form_display.node.highlight_item.default.yml
+++ b/sync/core.entity_form_display.node.highlight_item.default.yml
@@ -9,7 +9,7 @@ dependencies:
     - image.style.thumbnail
     - node.type.highlight_item
   module:
-    - image
+    - focal_point
 id: node.highlight_item.default
 targetEntityType: node
 bundle: highlight_item
@@ -29,8 +29,10 @@ content:
     settings:
       progress_indicator: throbber
       preview_image_style: thumbnail
+      preview_link: true
+      offsets: '50,50'
     third_party_settings: {  }
-    type: image_image
+    type: image_focal_point
     region: content
   status:
     type: boolean_checkbox

--- a/sync/core.entity_form_display.node.interview.default.yml
+++ b/sync/core.entity_form_display.node.interview.default.yml
@@ -15,7 +15,7 @@ dependencies:
     - image.style.thumbnail
     - node.type.interview
   module:
-    - image
+    - focal_point
     - paragraphs
     - text
 id: node.interview.default
@@ -47,8 +47,10 @@ content:
     settings:
       progress_indicator: throbber
       preview_image_style: thumbnail
+      preview_link: true
+      offsets: '50,50'
     third_party_settings: {  }
-    type: image_image
+    type: image_focal_point
     region: content
   field_impact_statement:
     weight: 4

--- a/sync/core.entity_form_display.node.labs_experiment.default.yml
+++ b/sync/core.entity_form_display.node.labs_experiment.default.yml
@@ -14,7 +14,7 @@ dependencies:
     - image.style.thumbnail
     - node.type.labs_experiment
   module:
-    - image
+    - focal_point
     - paragraphs
     - text
 id: node.labs_experiment.default
@@ -53,8 +53,10 @@ content:
     settings:
       progress_indicator: throbber
       preview_image_style: thumbnail
+      preview_link: true
+      offsets: '50,50'
     third_party_settings: {  }
-    type: image_image
+    type: image_focal_point
     region: content
   field_image_attribution:
     weight: 2

--- a/sync/core.entity_form_display.node.person.default.yml
+++ b/sync/core.entity_form_display.node.person.default.yml
@@ -20,7 +20,7 @@ dependencies:
     - image.style.thumbnail
     - node.type.person
   module:
-    - image
+    - focal_point
     - paragraphs
     - text
 id: node.person.default
@@ -40,8 +40,10 @@ content:
     settings:
       progress_indicator: throbber
       preview_image_style: thumbnail
+      preview_link: true
+      offsets: '50,50'
     third_party_settings: {  }
-    type: image_image
+    type: image_focal_point
     region: content
   field_person_affiliation:
     type: entity_reference_paragraphs

--- a/sync/core.entity_form_display.node.podcast_episode.default.yml
+++ b/sync/core.entity_form_display.node.podcast_episode.default.yml
@@ -15,7 +15,7 @@ dependencies:
     - image.style.thumbnail
     - node.type.podcast_episode
   module:
-    - image
+    - focal_point
     - inline_entity_form
     - link
     - text
@@ -64,8 +64,10 @@ content:
     settings:
       progress_indicator: throbber
       preview_image_style: thumbnail
+      preview_link: true
+      offsets: '50,50'
     third_party_settings: {  }
-    type: image_image
+    type: image_focal_point
     region: content
   field_image_attribution:
     weight: 2

--- a/sync/core.entity_form_display.paragraph.image.default.yml
+++ b/sync/core.entity_form_display.paragraph.image.default.yml
@@ -12,7 +12,7 @@ dependencies:
     - image.style.thumbnail
     - paragraphs.paragraphs_type.image
   module:
-    - image
+    - focal_point
     - text
 id: paragraph.image.default
 targetEntityType: paragraph
@@ -48,8 +48,10 @@ content:
     settings:
       progress_indicator: throbber
       preview_image_style: thumbnail
+      preview_link: true
+      offsets: '50,50'
     third_party_settings: {  }
-    type: image_image
+    type: image_focal_point
     region: content
   field_block_image_inline:
     weight: 5

--- a/sync/core.entity_view_display.entity_subqueue.covers_preview.default.yml
+++ b/sync/core.entity_view_display.entity_subqueue.covers_preview.default.yml
@@ -19,4 +19,12 @@ content:
     third_party_settings: {  }
     type: number_integer
     region: content
+  items:
+    label: hidden
+    type: entity_reference_label
+    weight: 0
+    region: content
+    settings:
+      link: true
+    third_party_settings: {  }
 hidden: {  }

--- a/sync/image.style.crop_16x9_250x141.yml
+++ b/sync/image.style.crop_16x9_250x141.yml
@@ -14,3 +14,4 @@ effects:
     data:
       width: 250
       height: 141
+      crop_type: focal_point

--- a/sync/image.style.crop_16x9_500x281.yml
+++ b/sync/image.style.crop_16x9_500x281.yml
@@ -14,3 +14,4 @@ effects:
     data:
       width: 500
       height: 281
+      crop_type: focal_point

--- a/sync/image.style.crop_1x1_140x140.yml
+++ b/sync/image.style.crop_1x1_140x140.yml
@@ -14,3 +14,4 @@ effects:
     data:
       width: 140
       height: 140
+      crop_type: focal_point

--- a/sync/image.style.crop_1x1_70x70.yml
+++ b/sync/image.style.crop_1x1_70x70.yml
@@ -14,3 +14,4 @@ effects:
     data:
       width: 70
       height: 70
+      crop_type: focal_point

--- a/sync/image.style.crop_2x1_1800x900.yml
+++ b/sync/image.style.crop_2x1_1800x900.yml
@@ -14,3 +14,4 @@ effects:
     data:
       width: 1800
       height: 900
+      crop_type: focal_point

--- a/sync/image.style.crop_2x1_900x450.yml
+++ b/sync/image.style.crop_2x1_900x450.yml
@@ -14,3 +14,4 @@ effects:
     data:
       width: 900
       height: 450
+      crop_type: focal_point


### PR DESCRIPTION
In the last update the form widget for images was switched to the standard without the ability to select a focal point. This reinstates the focal point.