### PR TITLE
Publication date can be scheduled

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -60,7 +60,7 @@
     "drupal/confi": "^1.4",
     "webmozart/path-util": "^2.3",
     "sebastian/version": "~1.0.6",
-    "drupal/publication_date": "1.x-dev"
+    "drupal/scheduler": "^1.0"
   },
   "require-dev": {
     "drupal/drupal-extension": "^3.4",
@@ -129,9 +129,6 @@
       },
       "drupal/paragraphs": {
         "Add Paragraphs support for view output as entity reference options (2935525)": "https://www.drupal.org/files/issues/paragraphs-add_support_for_views_output_as_entity_reference_options-2935525-2.patch"
-      },
-      "drupal/publication_date": {
-        "Port Publication Date to D8 (2606820)": "https://www.drupal.org/files/issues/2606820-13.patch"
       }
     }
   }

--- a/composer.json
+++ b/composer.json
@@ -59,7 +59,8 @@
     "drupal/entity_reference_unpublished": "^1.0@alpha",
     "drupal/confi": "^1.4",
     "webmozart/path-util": "^2.3",
-    "sebastian/version": "~1.0.6"
+    "sebastian/version": "~1.0.6",
+    "drupal/publication_date": "1.x-dev"
   },
   "require-dev": {
     "drupal/drupal-extension": "^3.4",
@@ -128,6 +129,9 @@
       },
       "drupal/paragraphs": {
         "Add Paragraphs support for view output as entity reference options (2935525)": "https://www.drupal.org/files/issues/paragraphs-add_support_for_views_output_as_entity_reference_options-2935525-2.patch"
+      },
+      "drupal/publication_date": {
+        "Port Publication Date to D8 (2606820)": "https://www.drupal.org/files/issues/2606820-13.patch"
       }
     }
   }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "40eb48fd3a032547de85dbce53db87af",
+    "content-hash": "611902dcb32e1fe78b9dd43760507e86",
     "packages": [
         {
             "name": "alchemy/zippy",
@@ -3571,6 +3571,64 @@
             "support": {
                 "source": "http://cgit.drupalcode.org/paragraphs"
             }
+        },
+        {
+            "name": "drupal/publication_date",
+            "version": "dev-1.x",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupal.org/project/publication_date",
+                "reference": "883d4a8801d4cafc3fee9ae0ef4062f85a8d6cd9"
+            },
+            "require": {
+                "drupal/core": "~8.0"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "branch-alias": {
+                    "dev-1.x": "1.x-dev"
+                },
+                "drupal": {
+                    "version": "8.x-1.x-dev",
+                    "datestamp": "1454033339",
+                    "security-coverage": {
+                        "status": "not-covered",
+                        "message": "Dev releases are not covered by Drupal security advisories."
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0+"
+            ],
+            "authors": [
+                {
+                    "name": "Clever Age",
+                    "homepage": "https://www.drupal.org/user/547746"
+                },
+                {
+                    "name": "Sheldon Rampton",
+                    "homepage": "https://www.drupal.org/user/13085"
+                },
+                {
+                    "name": "dgtlmoon",
+                    "homepage": "https://www.drupal.org/user/25027"
+                },
+                {
+                    "name": "jstoller",
+                    "homepage": "https://www.drupal.org/user/99012"
+                },
+                {
+                    "name": "tmarly",
+                    "homepage": "https://www.drupal.org/user/159040"
+                }
+            ],
+            "description": "Add a field containing the publication date.",
+            "homepage": "https://www.drupal.org/project/publication_date",
+            "support": {
+                "source": "http://cgit.drupalcode.org/publication_date"
+            },
+            "time": "2016-01-29T01:13:34+00:00"
         },
         {
             "name": "drupal/redis",
@@ -9877,6 +9935,7 @@
         "drupal/monolog": 15,
         "drupal/country": 10,
         "drupal/entity_reference_unpublished": 15,
+        "drupal/publication_date": 20,
         "elife/api": 20,
         "elife/api-validator": 20
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "611902dcb32e1fe78b9dd43760507e86",
+    "content-hash": "ef4c4e2885d824b4cf56b579516f8465",
     "packages": [
         {
             "name": "alchemy/zippy",
@@ -3573,64 +3573,6 @@
             }
         },
         {
-            "name": "drupal/publication_date",
-            "version": "dev-1.x",
-            "source": {
-                "type": "git",
-                "url": "https://git.drupal.org/project/publication_date",
-                "reference": "883d4a8801d4cafc3fee9ae0ef4062f85a8d6cd9"
-            },
-            "require": {
-                "drupal/core": "~8.0"
-            },
-            "type": "drupal-module",
-            "extra": {
-                "branch-alias": {
-                    "dev-1.x": "1.x-dev"
-                },
-                "drupal": {
-                    "version": "8.x-1.x-dev",
-                    "datestamp": "1454033339",
-                    "security-coverage": {
-                        "status": "not-covered",
-                        "message": "Dev releases are not covered by Drupal security advisories."
-                    }
-                }
-            },
-            "notification-url": "https://packages.drupal.org/8/downloads",
-            "license": [
-                "GPL-2.0+"
-            ],
-            "authors": [
-                {
-                    "name": "Clever Age",
-                    "homepage": "https://www.drupal.org/user/547746"
-                },
-                {
-                    "name": "Sheldon Rampton",
-                    "homepage": "https://www.drupal.org/user/13085"
-                },
-                {
-                    "name": "dgtlmoon",
-                    "homepage": "https://www.drupal.org/user/25027"
-                },
-                {
-                    "name": "jstoller",
-                    "homepage": "https://www.drupal.org/user/99012"
-                },
-                {
-                    "name": "tmarly",
-                    "homepage": "https://www.drupal.org/user/159040"
-                }
-            ],
-            "description": "Add a field containing the publication date.",
-            "homepage": "https://www.drupal.org/project/publication_date",
-            "support": {
-                "source": "http://cgit.drupalcode.org/publication_date"
-            },
-            "time": "2016-01-29T01:13:34+00:00"
-        },
-        {
             "name": "drupal/redis",
             "version": "1.0.0-rc2",
             "source": {
@@ -3742,6 +3684,74 @@
                 "source": "http://cgit.drupalcode.org/restui"
             },
             "time": "2017-06-08T10:55:43+00:00"
+        },
+        {
+            "name": "drupal/scheduler",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupal.org/project/scheduler",
+                "reference": "8.x-1.0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/scheduler-8.x-1.0.zip",
+                "reference": "8.x-1.0",
+                "shasum": "213025b64b417f459b73d260d7287ca1f916d587"
+            },
+            "require": {
+                "drupal/core": "*"
+            },
+            "require-dev": {
+                "drupal/devel_generate": "*",
+                "drupal/rules": "*"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "branch-alias": {
+                    "dev-1.x": "1.x-dev"
+                },
+                "drupal": {
+                    "version": "8.x-1.0",
+                    "datestamp": "1510690385",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0+"
+            ],
+            "authors": [
+                {
+                    "name": "Eric Schaefer (Eric Schaefer)",
+                    "homepage": "https://www.drupal.org/u/eric-schaefer",
+                    "role": "Maintainer"
+                },
+                {
+                    "name": "Jonathan Smith (jonathan1055)",
+                    "homepage": "https://www.drupal.org/u/jonathan1055",
+                    "role": "Maintainer"
+                },
+                {
+                    "name": "Pieter Frenssen (pfrenssen)",
+                    "homepage": "https://www.drupal.org/u/pfrenssen",
+                    "role": "Maintainer"
+                },
+                {
+                    "name": "Rick Manelius (rickmanelius)",
+                    "homepage": "https://www.drupal.org/u/rickmanelius",
+                    "role": "Maintainer"
+                }
+            ],
+            "description": "Automatically publish and unpublish content at specified dates and times.",
+            "homepage": "https://drupal.org/project/scheduler",
+            "support": {
+                "source": "http://cgit.drupalcode.org/scheduler",
+                "issues": "https://www.drupal.org/project/issues/scheduler"
+            }
         },
         {
             "name": "drupal/services",
@@ -9935,7 +9945,6 @@
         "drupal/monolog": 15,
         "drupal/country": 10,
         "drupal/entity_reference_unpublished": 15,
-        "drupal/publication_date": 20,
         "elife/api": 20,
         "elife/api-validator": 20
     },

--- a/src/modules/jcms_admin/jcms_admin.info.yml
+++ b/src/modules/jcms_admin/jcms_admin.info.yml
@@ -4,4 +4,5 @@ description: Admin improvements.
 core: 8.x
 dependencies:
   - jcms_rest
+  - scheduler
 package: Journal CMS

--- a/src/modules/jcms_admin/jcms_admin.module
+++ b/src/modules/jcms_admin/jcms_admin.module
@@ -541,4 +541,13 @@ function jcms_admin_node_presave(Node $node) {
       }
     }
   }
+
+  if (
+    $node->type->entity->getThirdPartySetting('scheduler', 'publish_enable', \Drupal::config('scheduler.settings')->get('default_publish_enable')) && $node->id() &&
+    !(bool) $node->get('publish_on')->getValue() &&
+    !$node->original->isPublished() &&
+    $node->isPublished()
+  ) {
+    $node->setCreatedTime($node->getChangedTime());
+  }
 }

--- a/src/modules/jcms_admin/jcms_admin.module
+++ b/src/modules/jcms_admin/jcms_admin.module
@@ -542,8 +542,11 @@ function jcms_admin_node_presave(Node $node) {
     }
   }
 
+  // If content that is configured to use scheduler module and switches from
+  // unpublished to published then set the created date to be now.
   if (
-    $node->type->entity->getThirdPartySetting('scheduler', 'publish_enable', \Drupal::config('scheduler.settings')->get('default_publish_enable')) && $node->id() &&
+    $node->type->entity->getThirdPartySetting('scheduler', 'publish_enable', \Drupal::config('scheduler.settings')->get('default_publish_enable')) &&
+    $node->id() &&
     !(bool) $node->get('publish_on')->getValue() &&
     !$node->original->isPublished() &&
     $node->isPublished()

--- a/sync/core.entity_form_display.node.annual_report.default.yml
+++ b/sync/core.entity_form_display.node.annual_report.default.yml
@@ -61,6 +61,12 @@ content:
     third_party_settings: {  }
     type: link_default
     region: content
+  publish_on:
+    type: datetime_timestamp_no_default
+    weight: 30
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   status:
     type: boolean_checkbox
     settings:
@@ -76,6 +82,12 @@ content:
       placeholder: ''
     third_party_settings: {  }
     region: content
+  unpublish_on:
+    type: datetime_timestamp_no_default
+    weight: 30
+    region: content
+    settings: {  }
+    third_party_settings: {  }
 hidden:
   created: true
   field_order_date: true

--- a/sync/core.entity_form_display.node.article.default.yml
+++ b/sync/core.entity_form_display.node.article.default.yml
@@ -42,6 +42,12 @@ content:
     third_party_settings: {  }
     type: number
     region: content
+  publish_on:
+    type: datetime_timestamp_no_default
+    weight: 30
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   status:
     type: boolean_checkbox
     settings:
@@ -57,6 +63,12 @@ content:
       placeholder: ''
     third_party_settings: {  }
     region: content
+  unpublish_on:
+    type: datetime_timestamp_no_default
+    weight: 30
+    region: content
+    settings: {  }
+    third_party_settings: {  }
 hidden:
   created: true
   field_article_json: true

--- a/sync/core.entity_form_display.node.blog_article.default.yml
+++ b/sync/core.entity_form_display.node.blog_article.default.yml
@@ -76,6 +76,12 @@ content:
     third_party_settings: {  }
     type: entity_reference_autocomplete
     region: content
+  publish_on:
+    type: datetime_timestamp_no_default
+    weight: 30
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   status:
     type: boolean_checkbox
     settings:
@@ -91,6 +97,12 @@ content:
       placeholder: ''
     third_party_settings: {  }
     region: content
+  unpublish_on:
+    type: datetime_timestamp_no_default
+    weight: 30
+    region: content
+    settings: {  }
+    third_party_settings: {  }
 hidden:
   created: true
   field_content_processed_json: true

--- a/sync/core.entity_form_display.node.collection.default.yml
+++ b/sync/core.entity_form_display.node.collection.default.yml
@@ -124,6 +124,12 @@ content:
       default_paragraph_type: paragraph
     third_party_settings: {  }
     region: content
+  publish_on:
+    type: datetime_timestamp_no_default
+    weight: 30
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   status:
     type: boolean_checkbox
     settings:
@@ -139,6 +145,12 @@ content:
       placeholder: ''
     third_party_settings: {  }
     region: content
+  unpublish_on:
+    type: datetime_timestamp_no_default
+    weight: 30
+    region: content
+    settings: {  }
+    third_party_settings: {  }
 hidden:
   created: true
   field_order_date: true

--- a/sync/core.entity_form_display.node.cover.default.yml
+++ b/sync/core.entity_form_display.node.cover.default.yml
@@ -56,6 +56,12 @@ content:
     third_party_settings: {  }
     type: moderation_state_default
     region: content
+  publish_on:
+    type: datetime_timestamp_no_default
+    weight: 30
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   status:
     type: boolean_checkbox
     settings:
@@ -71,6 +77,12 @@ content:
       placeholder: ''
     third_party_settings: {  }
     region: content
+  unpublish_on:
+    type: datetime_timestamp_no_default
+    weight: 30
+    region: content
+    settings: {  }
+    third_party_settings: {  }
 hidden:
   created: true
   field_order_date: true

--- a/sync/core.entity_form_display.node.event.default.yml
+++ b/sync/core.entity_form_display.node.event.default.yml
@@ -69,6 +69,12 @@ content:
     third_party_settings: {  }
     type: text_textarea
     region: content
+  publish_on:
+    type: datetime_timestamp_no_default
+    weight: 30
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   status:
     type: boolean_checkbox
     settings:
@@ -84,6 +90,12 @@ content:
       placeholder: ''
     third_party_settings: {  }
     region: content
+  unpublish_on:
+    type: datetime_timestamp_no_default
+    weight: 30
+    region: content
+    settings: {  }
+    third_party_settings: {  }
 hidden:
   created: true
   field_content_processed_json: true

--- a/sync/core.entity_form_display.node.highlight_item.default.yml
+++ b/sync/core.entity_form_display.node.highlight_item.default.yml
@@ -34,6 +34,12 @@ content:
     third_party_settings: {  }
     type: image_focal_point
     region: content
+  publish_on:
+    type: datetime_timestamp_no_default
+    weight: 30
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   status:
     type: boolean_checkbox
     settings:
@@ -49,6 +55,12 @@ content:
       placeholder: ''
     third_party_settings: {  }
     region: content
+  unpublish_on:
+    type: datetime_timestamp_no_default
+    weight: 30
+    region: content
+    settings: {  }
+    third_party_settings: {  }
 hidden:
   created: true
   field_order_date: true

--- a/sync/core.entity_form_display.node.highlight_list.default.yml
+++ b/sync/core.entity_form_display.node.highlight_list.default.yml
@@ -26,6 +26,12 @@ content:
     third_party_settings: {  }
     type: inline_entity_form_complex
     region: content
+  publish_on:
+    type: datetime_timestamp_no_default
+    weight: 30
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   status:
     type: boolean_checkbox
     settings:
@@ -41,6 +47,12 @@ content:
       placeholder: ''
     third_party_settings: {  }
     region: content
+  unpublish_on:
+    type: datetime_timestamp_no_default
+    weight: 30
+    region: content
+    settings: {  }
+    third_party_settings: {  }
 hidden:
   created: true
   field_order_date: true

--- a/sync/core.entity_form_display.node.interview.default.yml
+++ b/sync/core.entity_form_display.node.interview.default.yml
@@ -88,6 +88,12 @@ content:
     third_party_settings: {  }
     type: string_textfield
     region: content
+  publish_on:
+    type: datetime_timestamp_no_default
+    weight: 30
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   status:
     type: boolean_checkbox
     settings:
@@ -103,6 +109,12 @@ content:
       placeholder: ''
     third_party_settings: {  }
     region: content
+  unpublish_on:
+    type: datetime_timestamp_no_default
+    weight: 30
+    region: content
+    settings: {  }
+    third_party_settings: {  }
 hidden:
   created: true
   field_content_processed_json: true

--- a/sync/core.entity_form_display.node.job_advert.default.yml
+++ b/sync/core.entity_form_display.node.job_advert.default.yml
@@ -64,6 +64,12 @@ content:
     third_party_settings: {  }
     type: text_textarea
     region: content
+  publish_on:
+    type: datetime_timestamp_no_default
+    weight: 30
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   status:
     type: boolean_checkbox
     settings:
@@ -78,6 +84,12 @@ content:
     settings:
       size: 60
       placeholder: ''
+    third_party_settings: {  }
+  unpublish_on:
+    type: datetime_timestamp_no_default
+    weight: 30
+    region: content
+    settings: {  }
     third_party_settings: {  }
 hidden:
   created: true

--- a/sync/core.entity_form_display.node.labs_experiment.default.yml
+++ b/sync/core.entity_form_display.node.labs_experiment.default.yml
@@ -74,6 +74,12 @@ content:
     third_party_settings: {  }
     type: text_textarea
     region: content
+  publish_on:
+    type: datetime_timestamp_no_default
+    weight: 30
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   status:
     type: boolean_checkbox
     settings:
@@ -89,6 +95,12 @@ content:
       placeholder: ''
     third_party_settings: {  }
     region: content
+  unpublish_on:
+    type: datetime_timestamp_no_default
+    weight: 30
+    region: content
+    settings: {  }
+    third_party_settings: {  }
 hidden:
   created: true
   field_content_processed_json: true

--- a/sync/core.entity_form_display.node.person.default.yml
+++ b/sync/core.entity_form_display.node.person.default.yml
@@ -119,6 +119,12 @@ content:
       default_paragraph_type: ''
     third_party_settings: {  }
     region: content
+  publish_on:
+    type: datetime_timestamp_no_default
+    weight: 30
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   status:
     type: boolean_checkbox
     settings:
@@ -134,6 +140,12 @@ content:
       placeholder: ''
     third_party_settings: {  }
     region: content
+  unpublish_on:
+    type: datetime_timestamp_no_default
+    weight: 30
+    region: content
+    settings: {  }
+    third_party_settings: {  }
 hidden:
   created: true
   field_order_date: true

--- a/sync/core.entity_form_display.node.podcast_chapter.default.yml
+++ b/sync/core.entity_form_display.node.podcast_chapter.default.yml
@@ -48,6 +48,12 @@ content:
     third_party_settings: {  }
     type: entity_reference_autocomplete
     region: content
+  publish_on:
+    type: datetime_timestamp_no_default
+    weight: 30
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   status:
     type: boolean_checkbox
     settings:
@@ -63,6 +69,12 @@ content:
       placeholder: ''
     third_party_settings: {  }
     region: content
+  unpublish_on:
+    type: datetime_timestamp_no_default
+    weight: 30
+    region: content
+    settings: {  }
+    third_party_settings: {  }
 hidden:
   created: true
   field_order_date: true

--- a/sync/core.entity_form_display.node.podcast_episode.default.yml
+++ b/sync/core.entity_form_display.node.podcast_episode.default.yml
@@ -94,6 +94,12 @@ content:
     third_party_settings: {  }
     type: entity_reference_autocomplete
     region: content
+  publish_on:
+    type: datetime_timestamp_no_default
+    weight: 30
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   status:
     type: boolean_checkbox
     settings:
@@ -109,6 +115,12 @@ content:
       placeholder: ''
     third_party_settings: {  }
     region: content
+  unpublish_on:
+    type: datetime_timestamp_no_default
+    weight: 30
+    region: content
+    settings: {  }
+    third_party_settings: {  }
 hidden:
   created: true
   field_episode_chapters: true

--- a/sync/core.entity_form_display.node.press_package.default.yml
+++ b/sync/core.entity_form_display.node.press_package.default.yml
@@ -77,6 +77,12 @@ content:
     third_party_settings: {  }
     type: inline_entity_form_complex
     region: content
+  publish_on:
+    type: datetime_timestamp_no_default
+    weight: 30
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   status:
     type: boolean_checkbox
     settings:
@@ -92,6 +98,12 @@ content:
       placeholder: ''
     third_party_settings: {  }
     region: content
+  unpublish_on:
+    type: datetime_timestamp_no_default
+    weight: 30
+    region: content
+    settings: {  }
+    third_party_settings: {  }
 hidden:
   created: true
   field_content_processed_json: true

--- a/sync/core.extension.yml
+++ b/sync/core.extension.yml
@@ -68,6 +68,7 @@ module:
   workflows: 0
   menu_link_content: 1
   views: 10
+  publication_date: 99
   config_installer: 1000
 theme:
   stable: 0

--- a/sync/core.extension.yml
+++ b/sync/core.extension.yml
@@ -55,6 +55,7 @@ module:
   redis: 0
   rest: 0
   restui: 0
+  scheduler: 0
   serialization: 0
   services: 0
   shortcut: 0
@@ -68,7 +69,6 @@ module:
   workflows: 0
   menu_link_content: 1
   views: 10
-  publication_date: 99
   config_installer: 1000
 theme:
   stable: 0

--- a/sync/node.type.annual_report.yml
+++ b/sync/node.type.annual_report.yml
@@ -4,10 +4,22 @@ status: true
 dependencies:
   module:
     - menu_ui
+    - scheduler
 third_party_settings:
   menu_ui:
     available_menus: {  }
     parent: ''
+  scheduler:
+    expand_fieldset: when_required
+    fields_display_mode: vertical_tab
+    publish_enable: true
+    publish_past_date: error
+    publish_required: false
+    publish_revision: false
+    publish_touch: true
+    unpublish_enable: false
+    unpublish_required: false
+    unpublish_revision: false
 name: 'Annual report'
 type: annual_report
 description: ''

--- a/sync/node.type.blog_article.yml
+++ b/sync/node.type.blog_article.yml
@@ -4,10 +4,22 @@ status: true
 dependencies:
   module:
     - menu_ui
+    - scheduler
 third_party_settings:
   menu_ui:
     available_menus: {  }
     parent: ''
+  scheduler:
+    expand_fieldset: when_required
+    fields_display_mode: vertical_tab
+    publish_enable: true
+    publish_past_date: error
+    publish_required: false
+    publish_revision: false
+    publish_touch: true
+    unpublish_enable: false
+    unpublish_required: false
+    unpublish_revision: false
 name: 'Blog article'
 type: blog_article
 description: ''

--- a/sync/node.type.event.yml
+++ b/sync/node.type.event.yml
@@ -4,10 +4,22 @@ status: true
 dependencies:
   module:
     - menu_ui
+    - scheduler
 third_party_settings:
   menu_ui:
     available_menus: {  }
     parent: ''
+  scheduler:
+    expand_fieldset: when_required
+    fields_display_mode: vertical_tab
+    publish_enable: true
+    publish_past_date: error
+    publish_required: false
+    publish_revision: false
+    publish_touch: true
+    unpublish_enable: false
+    unpublish_required: false
+    unpublish_revision: false
 name: Event
 type: event
 description: ''

--- a/sync/node.type.interview.yml
+++ b/sync/node.type.interview.yml
@@ -4,10 +4,22 @@ status: true
 dependencies:
   module:
     - menu_ui
+    - scheduler
 third_party_settings:
   menu_ui:
     available_menus: {  }
     parent: ''
+  scheduler:
+    expand_fieldset: when_required
+    fields_display_mode: vertical_tab
+    publish_enable: true
+    publish_past_date: error
+    publish_required: false
+    publish_revision: false
+    publish_touch: true
+    unpublish_enable: false
+    unpublish_required: false
+    unpublish_revision: false
 name: Interview
 type: interview
 description: ''

--- a/sync/node.type.job_advert.yml
+++ b/sync/node.type.job_advert.yml
@@ -4,10 +4,22 @@ status: true
 dependencies:
   module:
     - menu_ui
+    - scheduler
 third_party_settings:
   menu_ui:
     available_menus: {  }
     parent: ''
+  scheduler:
+    expand_fieldset: when_required
+    fields_display_mode: vertical_tab
+    publish_enable: true
+    publish_past_date: error
+    publish_required: false
+    publish_revision: false
+    publish_touch: true
+    unpublish_enable: false
+    unpublish_required: false
+    unpublish_revision: false
 name: 'Job advert'
 type: job_advert
 description: ''

--- a/sync/node.type.labs_experiment.yml
+++ b/sync/node.type.labs_experiment.yml
@@ -4,10 +4,22 @@ status: true
 dependencies:
   module:
     - menu_ui
+    - scheduler
 third_party_settings:
   menu_ui:
     available_menus: {  }
     parent: ''
+  scheduler:
+    expand_fieldset: when_required
+    fields_display_mode: vertical_tab
+    publish_enable: true
+    publish_past_date: error
+    publish_required: false
+    publish_revision: false
+    publish_touch: true
+    unpublish_enable: false
+    unpublish_required: false
+    unpublish_revision: false
 name: 'Labs experiment'
 type: labs_experiment
 description: ''

--- a/sync/node.type.podcast_episode.yml
+++ b/sync/node.type.podcast_episode.yml
@@ -4,10 +4,22 @@ status: true
 dependencies:
   module:
     - menu_ui
+    - scheduler
 third_party_settings:
   menu_ui:
     available_menus: {  }
     parent: ''
+  scheduler:
+    expand_fieldset: when_required
+    fields_display_mode: vertical_tab
+    publish_enable: true
+    publish_past_date: error
+    publish_required: false
+    publish_revision: false
+    publish_touch: true
+    unpublish_enable: false
+    unpublish_required: false
+    unpublish_revision: false
 name: 'Podcast episode'
 type: podcast_episode
 description: ''

--- a/sync/node.type.press_package.yml
+++ b/sync/node.type.press_package.yml
@@ -4,10 +4,22 @@ status: true
 dependencies:
   module:
     - menu_ui
+    - scheduler
 third_party_settings:
   menu_ui:
     available_menus: {  }
     parent: ''
+  scheduler:
+    expand_fieldset: when_required
+    fields_display_mode: vertical_tab
+    publish_enable: true
+    publish_past_date: error
+    publish_required: false
+    publish_revision: false
+    publish_touch: true
+    unpublish_enable: false
+    unpublish_required: false
+    unpublish_revision: false
 name: 'Press package'
 type: press_package
 description: ''

--- a/sync/scheduler.settings.yml
+++ b/sync/scheduler.settings.yml
@@ -1,0 +1,21 @@
+allow_date_only: false
+date_format: 'Y-m-d H:i:s'
+date_letters: djmnFMyY
+date_only_format: Y-m-d
+default_expand_fieldset: when_required
+default_fields_display_mode: vertical_tab
+default_publish_enable: false
+default_publish_past_date: error
+default_publish_required: false
+default_publish_revision: false
+default_publish_touch: false
+default_time: '00:00:00'
+default_unpublish_enable: false
+default_unpublish_required: false
+default_unpublish_revision: false
+lightweight_cron_access_key: f8d68dd6e0bcd50c4075
+log: true
+time_letters: hHgGisaA
+time_only_format: 'H:i:s'
+_core:
+  default_config_hash: JOzWPTQNpL0mkZGbvh0o7T1wKYyGfC3DHHiwhjw2YhU

--- a/sync/user.role.editor.yml
+++ b/sync/user.role.editor.yml
@@ -58,6 +58,7 @@ permissions:
   - 'edit any press_package content'
   - 'manipulate entityqueues'
   - 'revert cover revisions'
+  - 'schedule publishing of nodes'
   - 'update covers_preview entityqueue'
   - 'use draft_draft transition'
   - 'use draft_published transition'
@@ -84,4 +85,5 @@ permissions:
   - 'view content moderation'
   - 'view latest version'
   - 'view moderation states'
+  - 'view scheduled content'
   - 'view the administration theme'

--- a/sync/views.view.scheduler_scheduled_content.yml
+++ b/sync/views.view.scheduler_scheduled_content.yml
@@ -1,0 +1,855 @@
+uuid: 764607cd-c2d3-46b1-acea-3d255a5a1379
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - scheduler
+    - user
+_core:
+  default_config_hash: 76OtYhIMKqji7okkzD9dtqaYCZyBjJdRFOsqJB1DDls
+id: scheduler_scheduled_content
+label: 'Scheduled content'
+module: node
+description: 'Find and manage scheduled content.'
+tag: default
+base_table: node_field_data
+base_field: nid
+core: 8.x
+display:
+  default:
+    display_options:
+      access:
+        type: scheduler
+      cache:
+        type: tag
+      query:
+        type: views_query
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Filter
+          reset_button: true
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      pager:
+        type: full
+        options:
+          items_per_page: 50
+          tags:
+            previous: '‹ previous'
+            next: 'next ›'
+            first: '« first'
+            last: 'last »'
+      style:
+        type: table
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+          override: true
+          sticky: true
+          caption: ''
+          summary: ''
+          description: ''
+          columns:
+            node_bulk_form: node_bulk_form
+            title: title
+            type: type
+            name: name
+            status: status
+            publish_on: publish_on
+            unpublish_on: unpublish_on
+            operations: operations
+          info:
+            node_bulk_form:
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            title:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            type:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            name:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            status:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            publish_on:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            unpublish_on:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            operations:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+          default: '-1'
+          empty_table: true
+      row:
+        type: fields
+      fields:
+        node_bulk_form:
+          id: node_bulk_form
+          table: node
+          field: node_bulk_form
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+          element_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          plugin_id: node_bulk_form
+          entity_type: node
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          label: Title
+          exclude: false
+          alter:
+            alter_text: false
+          element_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          entity_type: node
+          entity_field: title
+          type: string
+          settings:
+            link_to_entity: true
+          plugin_id: field
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: 'Content Type'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_label
+          settings:
+            link: false
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: node
+          entity_field: type
+          plugin_id: field
+        name:
+          id: name
+          table: users_field_data
+          field: name
+          relationship: uid
+          label: Author
+          exclude: false
+          alter:
+            alter_text: false
+          element_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          plugin_id: field
+          type: user_name
+          entity_type: user
+          entity_field: name
+        status:
+          id: status
+          table: node_field_data
+          field: status
+          label: Status
+          exclude: false
+          alter:
+            alter_text: false
+          element_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          type: boolean
+          settings:
+            format: custom
+            format_custom_true: Published
+            format_custom_false: Unpublished
+          plugin_id: field
+          entity_type: node
+          entity_field: status
+        publish_on:
+          id: publish_on
+          table: node_field_data
+          field: publish_on
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: 'Publish on'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          date_format: short
+          custom_date_format: ''
+          timezone: ''
+          entity_type: node
+          entity_field: publish_on
+          plugin_id: date
+        unpublish_on:
+          id: unpublish_on
+          table: node_field_data
+          field: unpublish_on
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: 'Unpublish on'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          date_format: short
+          custom_date_format: ''
+          timezone: ''
+          entity_type: node
+          entity_field: unpublish_on
+          plugin_id: date
+        operations:
+          id: operations
+          table: node
+          field: operations
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: Operations
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          destination: true
+          plugin_id: entity_operations
+      filters:
+        status:
+          id: status
+          table: node_field_data
+          field: status
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: '='
+          value: '1'
+          group: 1
+          exposed: true
+          expose:
+            operator_id: ''
+            label: Status
+            description: ''
+            use_operator: false
+            operator: status_op
+            identifier: status
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: true
+          group_info:
+            label: 'Published status'
+            description: ''
+            identifier: status
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items:
+              1:
+                title: Published
+                operator: '='
+                value: '1'
+              2:
+                title: Unpublished
+                operator: '='
+                value: '0'
+          plugin_id: boolean
+          entity_type: node
+          entity_field: status
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: in
+          value: {  }
+          group: 1
+          exposed: true
+          expose:
+            operator_id: type_op
+            label: Type
+            description: ''
+            use_operator: false
+            operator: type_op
+            identifier: type
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              administrator: '0'
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          plugin_id: bundle
+          entity_type: node
+          entity_field: type
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: contains
+          value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: title_op
+            label: Title
+            description: ''
+            use_operator: false
+            operator: title_op
+            identifier: title
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              administrator: '0'
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          plugin_id: string
+          entity_type: node
+          entity_field: title
+        langcode:
+          id: langcode
+          table: node_field_data
+          field: langcode
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: in
+          value: {  }
+          group: 1
+          exposed: true
+          expose:
+            operator_id: langcode_op
+            label: Language
+            description: ''
+            use_operator: false
+            operator: langcode_op
+            identifier: langcode
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              administrator: '0'
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          plugin_id: language
+          entity_type: node
+          entity_field: langcode
+        publish_on:
+          id: publish_on
+          table: node_field_data
+          field: publish_on
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: 'not empty'
+          value:
+            min: ''
+            max: ''
+            value: ''
+            type: date
+          group: 2
+          exposed: false
+          expose:
+            operator_id: publish_on_op
+            label: 'Publish on'
+            description: ''
+            use_operator: true
+            operator: publish_on_op
+            identifier: publish_on
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              administrator: '0'
+          is_grouped: false
+          group_info:
+            label: 'Publish on'
+            description: null
+            identifier: publish_on
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items:
+              1: {  }
+              2: {  }
+              3: {  }
+          entity_type: node
+          entity_field: publish_on
+          plugin_id: date
+        unpublish_on:
+          id: unpublish_on
+          table: node_field_data
+          field: unpublish_on
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: 'not empty'
+          value:
+            min: ''
+            max: ''
+            value: ''
+            type: date
+          group: 2
+          exposed: false
+          expose:
+            operator_id: unpublish_on_op
+            label: 'Unpublish on'
+            description: ''
+            use_operator: false
+            operator: unpublish_on_op
+            identifier: unpublish_on
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              administrator: '0'
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          entity_type: node
+          entity_field: unpublish_on
+          plugin_id: date
+      sorts: {  }
+      title: 'Scheduled Content'
+      empty:
+        area_text_custom:
+          id: area_text_custom
+          table: views
+          field: area_text_custom
+          relationship: none
+          group_type: group
+          admin_label: ''
+          empty: true
+          tokenize: false
+          content: 'No scheduled content.'
+          plugin_id: text_custom
+      arguments: {  }
+      relationships:
+        uid:
+          id: uid
+          table: node_field_data
+          field: uid
+          admin_label: author
+          required: true
+          plugin_id: standard
+      show_admin_links: false
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+          2: OR
+      display_extenders: {  }
+    display_plugin: default
+    display_title: Master
+    id: default
+    position: 0
+    cache_metadata:
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - user
+        - 'user.node_grants:view'
+      cacheable: false
+      max-age: 0
+      tags: {  }
+  overview:
+    display_options:
+      path: admin/content/scheduled
+      menu:
+        type: tab
+        title: Scheduled
+        description: ''
+        parent: system.admin_content
+        weight: -10
+        context: '0'
+        menu_name: admin
+      tab_options:
+        type: normal
+        title: Content
+        description: 'Find and manage scheduled content'
+        menu_name: admin
+        weight: -10
+      display_extenders: {  }
+      display_description: 'Overview of all scheduled content, as a tab on main ''content admin'' page'
+    display_plugin: page
+    display_title: 'Content Overview'
+    id: overview
+    position: 1
+    cache_metadata:
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - user
+        - 'user.node_grants:view'
+      cacheable: false
+      max-age: 0
+      tags: {  }
+  user_page:
+    display_options:
+      path: user/%user/scheduled
+      menu:
+        type: tab
+        title: Scheduled
+        description: ''
+        parent: system.admin_content
+        weight: -10
+        context: '0'
+        menu_name: admin
+      tab_options:
+        type: normal
+        title: Content
+        description: 'Find and manage scheduled content'
+        menu_name: admin
+        weight: -10
+      display_extenders: {  }
+      display_description: 'Scheduled content tab on user profile, showing just that user''s scheduled content'
+      defaults:
+        filters: true
+        filter_groups: true
+        arguments: false
+        access: true
+        empty: false
+      arguments:
+        uid:
+          id: uid
+          table: node_field_data
+          field: uid
+          relationship: none
+          group_type: group
+          admin_label: ''
+          default_action: empty
+          exception:
+            value: all
+            title_enable: false
+            title: All
+          title_enable: false
+          title: ''
+          default_argument_type: fixed
+          default_argument_options:
+            argument: ''
+          default_argument_skip_url: false
+          summary_options:
+            base_path: ''
+            count: true
+            items_per_page: 25
+            override: false
+          summary:
+            sort_order: asc
+            number_of_records: 0
+            format: default_summary
+          specify_validation: false
+          validate:
+            type: none
+            fail: 'not found'
+          validate_options: {  }
+          break_phrase: false
+          not: false
+          entity_type: node
+          entity_field: uid
+          plugin_id: numeric
+      empty:
+        area_text_custom:
+          id: area_text_custom
+          table: views
+          field: area_text_custom
+          relationship: none
+          group_type: group
+          admin_label: ''
+          empty: true
+          tokenize: true
+          content: 'No scheduled content for user {{ arguments.uid }}'
+          plugin_id: text_custom
+    display_plugin: page
+    display_title: 'User profile tab'
+    id: user_page
+    position: 2
+    cache_metadata:
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - user
+        - 'user.node_grants:view'
+      cacheable: false
+      max-age: 0
+      tags: {  }


### PR DESCRIPTION
Prior to this the publication date has been the date that content was created. This is fine if the content is immediately published but in some instances you want to prepare content prior to publication.

This is solved by enabling the `scheduler` module and to enable a schedule date to be set for relevant content types. You can set a date in the future and once this date has passed the content will be published in a subsequent `cron` run and the published date stored.

Additionally, the date that content switches from unpublished to published is recorded and used as the created date.