### PR TITLE
Support table markup in WYSIWYG

### DIFF
--- a/src/modules/jcms_rest/src/JCMSHtmlHelperTrait.php
+++ b/src/modules/jcms_rest/src/JCMSHtmlHelperTrait.php
@@ -39,8 +39,9 @@ trait JCMSHtmlHelperTrait {
     $new_split = [];
     $table_found = [];
     foreach ($split as $item) {
+      $item = trim($item);
       if (empty($table_found)) {
-        if (strpos(trim($item), '<table') === 0) {
+        if (strpos($item, '<table') === 0) {
           $table_found[] = $item;
         }
         else {
@@ -51,7 +52,7 @@ trait JCMSHtmlHelperTrait {
         $table_found[] = $item;
 
       }
-      if (!empty($table_found) && substr(trim($item), -8) === '</table>') {
+      if (!empty($table_found) && substr($item, -8) === '</table>') {
         $new_split[] = implode('', $table_found);
         $table_found = [];
       }

--- a/src/modules/jcms_rest/src/JCMSHtmlHelperTrait.php
+++ b/src/modules/jcms_rest/src/JCMSHtmlHelperTrait.php
@@ -24,49 +24,91 @@ trait JCMSHtmlHelperTrait {
       $node->parentNode->replaceChild($new_node->firstChild, $node);
     }
     $html = preg_replace('~</(ul|ol)><(ol|ul)~', "</$1>\n<$2", Html::serialize($dom));
-    $split = preg_split('/\n+/', $html);
+    $split = $this->gatherTables(array_filter(preg_split('/\n+/', $html)));
 
-    return array_map([$this, 'convertHtmlListToSchema'], array_filter($split));
+    return array_map([$this, 'convertHtmlToSchema'], $split);
   }
 
   /**
-   * Convert HTML list on single line to schema structure.
+   * Gather adjacent lines with tables.
+   *
+   * @param array $split
+   * @return array
+   */
+  public function gatherTables(array $split) {
+    $new_split = [];
+    $table_found = [];
+    foreach ($split as $item) {
+      if (empty($table_found)) {
+        if (strpos(trim($item), '<table') === 0) {
+          $table_found[] = $item;
+        }
+        else {
+          $new_split[] = $item;
+        }
+      }
+      else {
+        $table_found[] = $item;
+
+      }
+      if (!empty($table_found) && substr(trim($item), -8) === '</table>') {
+        $new_split[] = implode('', $table_found);
+        $table_found = [];
+      }
+    }
+
+    return $new_split;
+  }
+
+  /**
+   * Convert HTML on single line to schema structure.
    *
    * @param string $html
    * @return array|string
    */
-  public function convertHtmlListToSchema(string $html) {
-    if (!preg_match('~^\s*<(ul|ol)[^>]*>.*</\1>\s*$~', $html)) {
+  public function convertHtmlToSchema(string $html) {
+    if (!preg_match('~^\s*<(table|ul|ol)[^>]*>.*</\1>\s*$~', $html)) {
       return $html;
     }
     $dom = Html::load($html);
     $xpath = new \DOMXPath($dom);
     $node = $xpath->query('//body/*')->item(0);
-    $schema = [
-      'type' => 'list',
-      'prefix' => ($node->nodeName == 'ol') ? 'number' : 'bullet',
-      'items' => [],
-    ];
-    foreach ($node->getElementsByTagName('li') as $item) {
-      $item_value = '';
-      $child_list = [];
-      foreach ($item->childNodes as $child) {
-        if (in_array($child->nodeName, ['ol', 'ul'])) {
-          $item->removeChild($child);
-          $child_list = [$this->convertHtmlListToSchema($child->ownerDocument->saveXML($child))];
-        }
-        else {
-          $item_value .= $child->ownerDocument->saveXML($child);
-        }
-      }
-      $item_value = trim($item_value);
-      if (!empty($item_value)) {
-        $schema['items'][] = $item_value;
-      }
-      if (!empty($child_list)) {
-        $schema['items'][] = $child_list;
-      }
+
+    if ($node->nodeName == 'table') {
+      return [
+        'type' => 'table',
+        'tables' => [
+          trim($html),
+        ],
+      ];
     }
-    return $schema;
+    else {
+      $schema = [
+        'type' => 'list',
+        'prefix' => ($node->nodeName == 'ol') ? 'number' : 'bullet',
+        'items' => [],
+      ];
+      foreach ($node->getElementsByTagName('li') as $item) {
+        $item_value = '';
+        $child_list = [];
+        foreach ($item->childNodes as $child) {
+          if (in_array($child->nodeName, ['ol', 'ul'])) {
+            $item->removeChild($child);
+            $child_list = [$this->convertHtmlToSchema($child->ownerDocument->saveXML($child))];
+          }
+          else {
+            $item_value .= $child->ownerDocument->saveXML($child);
+          }
+        }
+        $item_value = trim($item_value);
+        if (!empty($item_value)) {
+          $schema['items'][] = $item_value;
+        }
+        if (!empty($child_list)) {
+          $schema['items'][] = $child_list;
+        }
+      }
+      return $schema;
+    }
   }
 }

--- a/src/modules/jcms_rest/tests/src/Unit/JCMSHtmlHelperTraitTest.php
+++ b/src/modules/jcms_rest/tests/src/Unit/JCMSHtmlHelperTraitTest.php
@@ -100,8 +100,8 @@ class JCMSHtmlHelperTraitTest extends UnitTestCase {
           ],
         ],
       ],
-      'paragraphs-with-table-multi-line' => [
-        "Paragraph one\n\n<table>\n<tr>\n<td>Cell one</td>\n</tr></table>\n\nParagraph two",
+      'paragraphs-with-table-multi-line-with-whitespace' => [
+        "Paragraph one\n\n<table>\n<tr>\n<td>Cell one</td>\n\t</tr></table>\n\nParagraph two",
         [
           "Paragraph one",
           [

--- a/src/modules/jcms_rest/tests/src/Unit/JCMSHtmlHelperTraitTest.php
+++ b/src/modules/jcms_rest/tests/src/Unit/JCMSHtmlHelperTraitTest.php
@@ -17,7 +17,7 @@ class JCMSHtmlHelperTraitTest extends UnitTestCase {
   public function providerSplitParagraphs()
   {
     return [
-      [
+      'single-list-among-paragraphs' => [
         "Unlike relational databases, IIIF servers are not a commodity, and the choice of server implementation is going to constrain other parameters such as the image storage and the supported formats. Writing a server from scratch was not the appropriate solution for us as the work that it performs is non-trivial: cutting, resizing, rotating and especially converting images between different formats. Unlike for simpler domains like indexing text, image-related software has a huge amount of test cases to be verified, corresponding to images of all sizes, formats and colors. .\n\nThe IIIF Image API 2.0 allows several levels of compliance:\n\n<ul><li>Level 0 only allows full portions of the image, at predefined sizes</li>\n  <li>Level 1 adds the capability to request image portions, at any size</li>\n  <li>Level 2 adds rotation, and multiple output options such as grayscale and the PNG format</li>\n</ul>\n\nFor our own implementation of IIIF on eLife, we chose <a href=\"https://github.com/loris-imageserver/loris\">Loris</a>, an image server providing IIIF Image API Level 2. Loris is a small Python web application, backed by many Python and C libraries. We run Loris in <a href=\"https://uwsgi-docs.readthedocs.io/en/latest/\">uWSGI</a>, as we would do with any standard Python web application.\n\nWe expose Loris to the outside world through an Nginx server, which is capable of solving the standard problems of HTTP traffic such as setting cache headers and performing redirects. Nginx can scale to thousands of concurrent connections, and adds minimal overhead on top of the computationally intensive work of image manipulation.",
         [
           "Unlike relational databases, IIIF servers are not a commodity, and the choice of server implementation is going to constrain other parameters such as the image storage and the supported formats. Writing a server from scratch was not the appropriate solution for us as the work that it performs is non-trivial: cutting, resizing, rotating and especially converting images between different formats. Unlike for simpler domains like indexing text, image-related software has a huge amount of test cases to be verified, corresponding to images of all sizes, formats and colors. .",
@@ -35,7 +35,7 @@ class JCMSHtmlHelperTraitTest extends UnitTestCase {
           "We expose Loris to the outside world through an Nginx server, which is capable of solving the standard problems of HTTP traffic such as setting cache headers and performing redirects. Nginx can scale to thousands of concurrent connections, and adds minimal overhead on top of the computationally intensive work of image manipulation.",
         ],
       ],
-      [
+      'single-list-leading-paragraph' => [
         "Infrastructure in the real world is often referred to as the fundamental facilities of a country. In the computing world it consists of all the (now virtualized) hardware components that connect users with the information they want to obtain. In the case of IIIF, the laundry list for the required infrastructure consists of:\n\n<ul><li>Two or more virtual machines: `t2.medium` EC2 instances are inexpensive and good for bursts of increased compute power when there are peaks in traffic.</li>\n  <li>Their volumes: not-particularly-fast hard drives can be used as a cache of original and generated images. The standard storage provided by EC2 instances is only ~7 GB, of which most is occupied by the operating system. Additional volumes can be used as the second level of storage, to avoid cleaning the cache every half an hour.</li>\n  <li>Load balancing: servers can be detached one at a time from <a href=\"https://aws.amazon.com/elasticloadbalancing/\">ELBs</a>, in order to perform maintenance or cleaning operations like cache pruning without interrupting traffic. ELBs can also perform HTTPS termination, making the single IIIF servers easier to set up as they don't need to be configured with SSL certificates.</li>\n  <li>Content Delivery Networks (CDNs): CloudFront can be used for edge caching, storing cached versions of popular images near the user’s location to reduce latency. The benefit of CloudFront is its simplicity, although the lack of protection from cache stampedes and the fairly long time it takes to invalidate content and update its configurations are drawbacks.<br />\n   </li>\n</ul>",
         [
           "Infrastructure in the real world is often referred to as the fundamental facilities of a country. In the computing world it consists of all the (now virtualized) hardware components that connect users with the information they want to obtain. In the case of IIIF, the laundry list for the required infrastructure consists of:",
@@ -51,7 +51,7 @@ class JCMSHtmlHelperTraitTest extends UnitTestCase {
           ],
         ],
       ],
-      [
+      'multiple-lists' => [
         "Paragraph one:\n\n<ol>\n  <li>Item 1</li>\n  <li>Item 2\n    <ul>\n      <li>Item 2.1  <li>\n      <li>Item 2.2</li>\n    </ul>\n  </li><li>\n  Item 3\n  </li>\n</ol>\n\nParagraph two\n\nParagraph three:\n\n<ul>\n  <li>Item 1</li>\n  <li>Item 2</li>\n  <li>Item 3</li>\n</ul>\n\nParagraph four\n\n",
         [
           "Paragraph one:",
@@ -86,6 +86,31 @@ class JCMSHtmlHelperTraitTest extends UnitTestCase {
             ]
           ],
           "Paragraph four",
+        ],
+      ],
+      'paragraphs-with-table-single-line' => [
+        "Paragraph one\n\n<table><tr><td>Cell one</td></tr></table>",
+        [
+          "Paragraph one",
+          [
+            'type' => 'table',
+            'tables' => [
+              "<table><tr><td>Cell one</td></tr></table>",
+            ],
+          ],
+        ],
+      ],
+      'paragraphs-with-table-multi-line' => [
+        "Paragraph one\n\n<table>\n<tr>\n<td>Cell one</td>\n</tr></table>\n\nParagraph two",
+        [
+          "Paragraph one",
+          [
+            'type' => 'table',
+            'tables' => [
+              "<table><tr><td>Cell one</td></tr></table>",
+            ],
+          ],
+          "Paragraph two",
         ],
       ],
     ];


### PR DESCRIPTION
There are 3 labs posts where table markup has been inserted into the paragraph text. This was not anticipated and has been split into paragraph blocks.

This fixes adds support for `<table>` in the WYSIWYG editor in the same way that simple lists are supported.

Once this is deployed then the affected content items should be saved again in `journal-cms` to trigger a regeneration of the processed content block.

- https://elifesciences.org/labs/b6de9fb0
- https://elifesciences.org/labs/85a7155a
- https://elifesciences.org/labs/0af6527f