### PR TITLE
Return article snippet as array

### DIFF
--- a/src/modules/jcms_article/src/ArticleCrud.php
+++ b/src/modules/jcms_article/src/ArticleCrud.php
@@ -183,18 +183,18 @@ class ArticleCrud {
   /**
    * Get article snippet from node.
    *
-   * @return mixed|bool
+   * @return array|bool
    *   Return article snippet, if found.
    */
   public function getArticle(EntityInterface $node, bool $preview = FALSE) {
     $pid = $node->get('field_article_json')->getValue()[0]['target_id'];
     $paragraph = Paragraph::load($pid);
     if ($preview) {
-      return json_decode($paragraph->get('field_article_unpublished_json')->getString());
+      return json_decode($paragraph->get('field_article_unpublished_json')->getString(), TRUE);
     }
     else {
       if ($paragraph->get('field_article_published_json')->getValue()) {
-        return json_decode($paragraph->get('field_article_published_json')->getString());
+        return json_decode($paragraph->get('field_article_published_json')->getString(), TRUE);
       }
       else {
         return FALSE;


### PR DESCRIPTION
This bug was introduced here: https://github.com/elifesciences/journal-cms/pull/283/files#diff-a6775fe6ef2a26a4f98a8ace4209cb2dR64

The `getArticleSnippet` step was returning a json object.