### PR TITLE
ELPP-3475 Import the MSA chromosomes-gene-expression

### DIFF
--- a/src/modules/jcms_migrate/jcms_migrate.install
+++ b/src/modules/jcms_migrate/jcms_migrate.install
@@ -1029,3 +1029,13 @@ function jcms_migrate_update_8211() {
 function jcms_migrate_update_8212() {
   \Drupal::service('entity.definition_update_manager')->applyUpdates();
 }
+
+/**
+ * Import the MSA chromosomes-gene-expression.
+ */
+function jcms_migrate_update_8213() {
+  $manager = \Drupal::service('plugin.manager.config_entity_migration');
+  $plugins = $manager->createInstances([]);
+  $executable = new MigrateExecutable($plugins['jcms_subjects_json'], new MigrateMessage());
+  $executable->import();
+}

--- a/src/modules/jcms_migrate/migration_assets/subjects.json
+++ b/src/modules/jcms_migrate/migration_assets/subjects.json
@@ -104,6 +104,14 @@
     "alt": "Computational and Systems Biology"
   },
   {
+    "id": "chromosomes-gene-expression",
+    "name": "Chromosomes and Gene Expression",
+    "impact_statement": "eLife publishes research ranging from transcription and RNA processing to epigenetics and chromatin biology. Decisions are made by journal editors who are active researchers interested in chromosomes and gene expression.",
+    "aims_and_scope": "We aim to publish significant research, performed using genetic, biochemical and structural approaches, that relates to all aspects of the central dogma of biology, specifically DNA replication, repair and recombination, transcription and RNA processing, and translation. We welcome studies in organisms from bacteria to humans that provide new insights into the mechanisms of these processes – including how they are regulated, for example during cell differentiation – and the defects in these processes that contribute to disease. Read the latest research in this subject area.",
+    "image": "subjects/elife-sciences-chromosomes-and-gene-expression-illustration.jpg",
+    "alt": "Chromosomes and Gene Expression"
+  },
+  {
     "id": "cell-biology",
     "name": "Cell Biology",
     "impact_statement": "eLife publishes research spanning vesicle transport and signal transduction to cell cycle and cell polarity and fate. Decisions are made by <a href=\"/about/people\">journal editors</a> who are active researchers in cell biology.",


### PR DESCRIPTION
This should be merged in after the `journal` rewrite has been implemented.

After this has been deployed, if it a simple switch for all content to be assigned from `genes-chromosomes` to `chromosomes-gene-expression` then we can run the commands:

```
cd /srv/journal-cms/web
../vendor/bin/drush msa-switch genes-chromosomes chromosomes-gene-expression
```