### PR TITLE
ELPP-2762 Allow MSA switch script to work for orphaned MSA

### DIFF
--- a/scripts/sanitized-db-dump.sh
+++ b/scripts/sanitized-db-dump.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
-DEFAULT_STRUCTURED_TABLES_LIST=" --structure-tables-list='user__roles,user__user_picture,users,users_data,users_field_data'"
+DEFAULT_STRUCTURED_TABLES_LIST=" --structure-tables-list=user__roles,user__user_picture,users,users_data,users_field_data"
 
 if [[ ${*} =~ \-\-structure\-tables\-list ]];
 then

--- a/src/modules/jcms_migrate/drush/jcms_migrate.drush.inc
+++ b/src/modules/jcms_migrate/drush/jcms_migrate.drush.inc
@@ -64,10 +64,16 @@ function drush_jcms_migrate_msa_switch(string $from, string $to = NULL) {
   $to = $to ?? $from;
 
   // Verify that $from and $to are recognised.
-  $msa_from = \Drupal::entityQuery('taxonomy_term')
-    ->condition('vid', 'subjects')
-    ->condition('field_subject_id.value', $from)
-    ->execute();
+  if (is_numeric($from)) {
+    $msa_from = [$from];
+  }
+  else {
+    $msa_from = \Drupal::entityQuery('taxonomy_term')
+      ->condition('vid', 'subjects')
+      ->condition('field_subject_id.value', $from)
+      ->execute();
+  }
+
   if (!$msa_from) {
     return drush_set_error('jcms_migrate', dt('!from is not a recognised major subject area.', ['!from' => $from]));
   }

--- a/src/modules/jcms_migrate/jcms_migrate.install
+++ b/src/modules/jcms_migrate/jcms_migrate.install
@@ -1062,22 +1062,3 @@ function jcms_migrate_update_8124() {
     $migrate_id_map->delete([$id]);
   }
 }
-
-/**
- * Resave all person nodes with a competing interest.
- */
-function jcms_migrate_update_8125() {
-  $query = \Drupal::entityQuery('node')
-    ->condition('type', 'person')
-    // Limit the person nodes to those with a competing interest.
-    ->condition('field_person_competing.format', 'basic_html');
-  $nids = $query->execute();
-  if ($nids) {
-    $nodes = Node::loadMultiple($nids);
-    if (!empty($nodes)) {
-      foreach ($nodes as $node) {
-        $node->save();
-      }
-    }
-  }
-}

--- a/src/modules/jcms_rest/src/Plugin/rest/resource/PersonItemRestResource.php
+++ b/src/modules/jcms_rest/src/Plugin/rest/resource/PersonItemRestResource.php
@@ -87,11 +87,6 @@ class PersonItemRestResource extends AbstractRestResourceBase {
       $item['affiliations'] = $affiliations;
     }
 
-    // Competing interests are optional.
-    if ($competing = $this->fieldValueFormatted($node->get('field_person_competing'))) {
-      $item['competingInterests'] = $competing;
-    }
-
     return $item;
   }
 


### PR DESCRIPTION
Continuumtest has some orphaned MSA. The `../vendor/bin/drush msa-switch` script must not have been run on this instance before an MSA was removed. 

This script allows us to target the Drupal term id as the `from` value of the `msa-switch` command.

For example:

```
cd /srv/journal-cms/web
../vendor/bin/drush msa-switch 7 chromosomes-gene-expression
```