### PR TITLE
Improvements to the drush msa-switch command

### DIFF
--- a/src/modules/jcms_migrate/drush/jcms_migrate.drush.inc
+++ b/src/modules/jcms_migrate/drush/jcms_migrate.drush.inc
@@ -60,6 +60,8 @@ function jcms_migrate_drush_command() {
  * Callback function drush_jcms_admin_msa_switch().
  */
 function drush_jcms_migrate_msa_switch(string $from, string $to = NULL) {
+  // If $to is NULL then there is no need to trigger the save.
+  $skip_save = (is_null($to)) ? TRUE : FALSE;
   // Allow $to to be null to force save of all content under this MSA.
   $to = $to ?? $from;
 
@@ -157,6 +159,7 @@ function drush_jcms_migrate_msa_switch(string $from, string $to = NULL) {
         $swap_msa_values($node, 'field_subjects');
       }
       if ($verbose) {
+        // This is useful if content needs to be manually reassigned.
         drush_print(dt(':type (:uuid): :title (/node/!nid)', [
           ':type' => $node->bundle(),
           ':uuid' => substr($node->uuid(), -8),
@@ -164,11 +167,15 @@ function drush_jcms_migrate_msa_switch(string $from, string $to = NULL) {
           '!nid' => $node->id(),
         ]));
       }
-      $node->save();
+      if (!$skip_save) {
+        $node->save();
+      }
     }
   }
 
-  drush_print(dt('Switching complete!'));
+  if (!$skip_save) {
+    drush_print(dt('Switching complete!'));
+  }
 }
 
 /**

--- a/src/modules/jcms_migrate/drush/jcms_migrate.drush.inc
+++ b/src/modules/jcms_migrate/drush/jcms_migrate.drush.inc
@@ -63,6 +63,8 @@ function drush_jcms_migrate_msa_switch(string $from, string $to = NULL) {
   // Allow $to to be null to force save of all content under this MSA.
   $to = $to ?? $from;
 
+  $verbose = drush_get_context('DRUSH_VERBOSE');
+
   // Verify that $from and $to are recognised.
   if (is_numeric($from)) {
     $msa_from = [$from];
@@ -144,6 +146,7 @@ function drush_jcms_migrate_msa_switch(string $from, string $to = NULL) {
       '!count' => count($nodes),
       '!type' => $type,
     ]));
+    /** @var \Drupal\node\NodeInterface $node */
     foreach ($nodes as $node) {
       if ($type === 'person') {
         $details = Paragraph::load($people[$node->id()]->research_details_id);
@@ -152,6 +155,14 @@ function drush_jcms_migrate_msa_switch(string $from, string $to = NULL) {
       }
       else {
         $swap_msa_values($node, 'field_subjects');
+      }
+      if ($verbose) {
+        drush_print(dt(':type (:uuid): :title (/node/!nid)', [
+          ':type' => $node->bundle(),
+          ':uuid' => substr($node->uuid(), -8),
+          ':title' => $node->getTitle(),
+          '!nid' => $node->id(),
+        ]));
       }
       $node->save();
     }


### PR DESCRIPTION
When a new Major Subject Area (MSA) is introduced the `drush msa-switch` command will easily assign all content from one MSA to another. This is fine for simple renames of MSA but when an MSA is being split into multiple new MSA's then manually reassignment will be necessary. These tweaks will allow us to easily identify the content that needs to be reassigned.

The `verbose` flag can now be used to output the title and id of all tagged content and only supplying a `from` subject will mean that the command is considered to be for information gathering purposes only and the content will not be resaved:
```
drush msa-switch biochemistry-chemical-biology --verbose
```