### PR TITLE
If a patch doesn't apply - tests should fail

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -386,7 +386,7 @@
         "Use new Transliteration functionality in core for file names (2492171)": "https://www.drupal.org/files/issues/2019-01-29/2492171-3-151.patch",
         "Move permission \"view any unpublished content\" from content moderation to core (273595)": "https://www.drupal.org/files/issues/move_permission_view-273595-129.patch",
         "Temporary fix for \\Drupal\\Core\\Field\\FieldItemList::generateSampleItems (2905527)": "src/patches/2905527-temporary-fix-generate-sample-items.patch",
-        "This patch should not apply and should block": "https://www.drupal.org/files/issues/use_new_transliteration-2492171-51.patch"
+        "This patch should not apply and should block": "https://patch.not/found.patch"
       },
       "drupal/entity_reference_revisions": {
         "Allow entities to be generated if none exist (2910326)": "https://www.drupal.org/files/issues/entity_reference_revisions-stop_checking_for_entities_before_generating_sample-2910326-2.patch"

--- a/composer.json
+++ b/composer.json
@@ -386,7 +386,8 @@
         "Use new Transliteration functionality in core for file names (2492171)": "https://www.drupal.org/files/issues/2019-01-29/2492171-3-151.patch",
         "Move permission \"view any unpublished content\" from content moderation to core (273595)": "https://www.drupal.org/files/issues/move_permission_view-273595-129.patch",
         "Temporary fix for \\Drupal\\Core\\Field\\FieldItemList::generateSampleItems (2905527)": "src/patches/2905527-temporary-fix-generate-sample-items.patch",
-        "This patch should not apply and should block": "https://patch.not/found.patch"
+        "This patch should not apply and should trigger fail": "https://www.drupal.org/files/issues/use_new_transliteration-2492171-51.patch",
+        "This patch not found and should trigger fail": "https://patch.not/found.patch"
       },
       "drupal/entity_reference_revisions": {
         "Allow entities to be generated if none exist (2910326)": "https://www.drupal.org/files/issues/entity_reference_revisions-stop_checking_for_entities_before_generating_sample-2910326-2.patch"

--- a/composer.json
+++ b/composer.json
@@ -385,7 +385,8 @@
         "View output is not used for autocomplete display (2174633)": "https://www.drupal.org/files/issues/2174633-198.patch",
         "Use new Transliteration functionality in core for file names (2492171)": "https://www.drupal.org/files/issues/2019-01-29/2492171-3-151.patch",
         "Move permission \"view any unpublished content\" from content moderation to core (273595)": "https://www.drupal.org/files/issues/move_permission_view-273595-129.patch",
-        "Temporary fix for \\Drupal\\Core\\Field\\FieldItemList::generateSampleItems (2905527)": "src/patches/2905527-temporary-fix-generate-sample-items.patch"
+        "Temporary fix for \\Drupal\\Core\\Field\\FieldItemList::generateSampleItems (2905527)": "src/patches/2905527-temporary-fix-generate-sample-items.patch",
+        "This patch should not apply and should block": "https://www.drupal.org/files/issues/use_new_transliteration-2492171-51.patch"
       },
       "drupal/entity_reference_revisions": {
         "Allow entities to be generated if none exist (2910326)": "https://www.drupal.org/files/issues/entity_reference_revisions-stop_checking_for_entities_before_generating_sample-2910326-2.patch"


### PR DESCRIPTION
This should fail in CI and should block merge of PR.

This is the output of `cd /srv/journal-cms/web && composer install`

```
$ composer install
Gathering patches for root package.
Removing package drupal/core so that it can be re-installed and re-patched.
  - Removing drupal/core (8.6.7)
Deleting web/core - deleted
Loading composer repositories with package information
Installing dependencies (including require-dev) from lock file
Warning: The lock file is not up to date with the latest changes in composer.json. You may be getting outdated dependencies. Run update to update them.
Package operations: 1 install, 0 updates, 0 removals
Gathering patches for root package.
Gathering patches for dependencies. This might take a minute.
  - Installing drupal/core (8.6.7): Loading from cache
  - Applying patches for drupal/core
    https://www.drupal.org/files/issues/2174633-198.patch (View output is not used for autocomplete display (2174633))
    https://www.drupal.org/files/issues/2019-01-29/2492171-3-151.patch (Use new Transliteration functionality in core for file names (2492171))
    https://www.drupal.org/files/issues/move_permission_view-273595-129.patch (Move permission "view any unpublished content" from content moderation to core (273595))
    src/patches/2905527-temporary-fix-generate-sample-items.patch (Temporary fix for \Drupal\Core\Field\FieldItemList::generateSampleItems (2905527))
    https://www.drupal.org/files/issues/use_new_transliteration-2492171-51.patch (This patch should not apply and should trigger fail)
   Could not apply patch! Skipping. The error was: Cannot apply patch https://www.drupal.org/files/issues/use_new_transliteration-2492171-51.patch
    https://patch.not/found.patch (This patch not found and should trigger fail)
   Could not apply patch! Skipping. The error was: The "https://patch.not/found.patch" file could not be downloaded: php_network_getaddresses: getaddrinfo failed: Name or service not known
failed to open stream: php_network_getaddresses: getaddrinfo failed: Name or service not known

Generating autoload files
Dumping package paths
223 package paths dumped
ocramius/package-versions:  Generating version class...
ocramius/package-versions: ...done generating version class
> DrupalComposer\DrupalScaffold\Plugin::scaffold
> JCMSDrupalProject\composer\ScriptHandler::createRequiredFiles
```