### PR TITLE
Reverse the order of the starts_with array

### DIFF
--- a/src/modules/jcms_admin/src/EntityAutocompleteMatcher.php
+++ b/src/modules/jcms_admin/src/EntityAutocompleteMatcher.php
@@ -58,7 +58,7 @@ class EntityAutocompleteMatcher extends CoreEntityAutocompleteMatcher {
         $matches = array_slice($matches, 0, $limit);
         $starts_with = $this->getMatches($target_type, $selection_handler, ['match_operator' => 'STARTS_WITH'] + $selection_settings, $string);
         if (count($starts_with) > 0) {
-          foreach ($starts_with as $item) {
+          foreach (array_reverse($starts_with, TRUE) as $item) {
             array_unshift($matches, $item);
           }
           array_unique($matches);


### PR DESCRIPTION
Improves: https://github.com/elifesciences/issues/issues/4747

If the number of results in an autocomplete "contains" response is greater than the limit then we perform a "starts_with" query and add the results to the top of the list.

There was a bug with the order in which they were being ordered at the top of the list. This fix introduces the "starts_with" results in the correct order.