### PR TITLE
Clean leftover backups

### DIFF
--- a/scripts/download-backup.sh
+++ b/scripts/download-backup.sh
@@ -7,6 +7,9 @@ set -e
 delay="${1:-1}" # default to 1 day back
 TMP="${TMP:-/ext/tmp/}"
 
+echo "Cleaning leftover backups"
+rm -rf "${TMP}/*.gz"
+
 backupLocation='s3://elife-app-backups/journal-cms/'
 if [ "$(uname -s)" == "Darwin" ]; then
     # Mac OS X


### PR DESCRIPTION
Sometimes failures can leave in the temporary folder old files that are not used anymore but occupy space:
```
-rw-rw-r-- 1 elife elife  123566369 May 19 00:28 20190519_prod--journal-cms.elifesciences.org_002848-elife_2_0-mysql.gz
-rw-rw-r-- 1 elife elife  126807323 May 26 00:29 20190526_prod--journal-cms.elifesciences.org_002913-elife_2_0-mysql.gz
-rw-rw-r-- 1 elife elife 5247985158 May 26 00:29 20190526_prod--journal-cms.elifesciences.org_002916-archive-b47198f6.tar.gz
-rw-rw-r-- 1 elife elife  129798542 Jun  2 00:33 20190602_prod--journal-cms.elifesciences.org_003305-elife_2_0-mysql.gz
-rw-rw-r-- 1 elife elife 5257030283 Jun  2 00:33 20190602_prod--journal-cms.elifesciences.org_003308-archive-b47198f6.tar.gz
```