### PR TITLE
Validation should happen even if content is empty

### DIFF
--- a/src/modules/jcms_rest/src/ContentValidator.php
+++ b/src/modules/jcms_rest/src/ContentValidator.php
@@ -53,19 +53,17 @@ final class ContentValidator implements ValidatorInterface {
       ]);
       $response = $this->client->send($request);
       $json = json_decode($response->getBody()->getContents());
-      if (!empty($json->content)) {
-        try {
-          $this->messageValidator->validate($response);
-        }
-        catch (InvalidMessage $message) {
-          $context += [
-            'node' => $node->id(),
-            'json' => $json,
-            'html' => $node->get('field_content_html' . ($preview ? '_preview' : ''))->getValue(),
-          ];
-          $this->logger->error($message->getMessage(), $context);
-          throw $message;
-        }
+      try {
+        $this->messageValidator->validate($response);
+      }
+      catch (InvalidMessage $message) {
+        $context += [
+          'node' => $node->id(),
+          'json' => $json,
+          'html' => $node->get('field_content_html' . ($preview ? '_preview' : ''))->getValue(),
+        ];
+        $this->logger->error($message->getMessage(), $context);
+        throw $message;
       }
       return $json;
     }


### PR DESCRIPTION
Currently the validation check is bypassed if the content is empty. This means that if the content is empty then it will not be blocked from being published and it will mean that invalid content could be served to the journal. This should be fixed here.