### PR TITLE
Flush all caches before config import

### DIFF
--- a/src/modules/jcms_admin/jcms_admin.install
+++ b/src/modules/jcms_admin/jcms_admin.install
@@ -65,3 +65,10 @@ function jcms_admin_update_8105() {
   ];
   $config_importer->importConfigs($configs);
 }
+
+/**
+ * Flush all caches before config import.
+ */
+function jcms_admin_update_8106() {
+  drupal_flush_all_caches();
+}


### PR DESCRIPTION
Hoping this will resolve the issue with this deployment: https://calendar.google.com/calendar/b/1/r?pli=1