### PR TITLE
Uninstall admin_toolbar ~1.0

### DIFF
--- a/sync/core.extension.yml
+++ b/sync/core.extension.yml
@@ -1,7 +1,5 @@
 module:
   address: 0
-  admin_toolbar: 0
-  admin_toolbar_tools: 0
   basic_auth: 0
   block: 0
   block_content: 0


### PR DESCRIPTION
The next step will be to upgrade admin_toolbar to the 2.0 version and to install.