### PR TITLE
same patch but attached to appropriate issue on d.o.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -382,7 +382,7 @@
     },
     "patches": {
       "drupal/core": {
-        "Use new Transliteration functionality in core for file names (2492171)": "https://www.drupal.org/files/issues/2019-12-06/2492171-294.patch",
+        "Composer-friendly patches for filename sanitation while #2492171 awaits #3032390 (3094052)": "https://www.drupal.org/files/issues/2019-12-08/3094052-2.patch",
         "Move permission \"view any unpublished content\" from content moderation to core (273595)": "https://www.drupal.org/files/issues/2019-12-06/273595-164.patch",
         "Temporary fix for \\Drupal\\Core\\Field\\FieldItemList::generateSampleItems (2905527)": "src/patches/2905527-temporary-fix-generate-sample-items.patch"
       },


### PR DESCRIPTION
The patch that was previously listed is attached to a postponed issue on drupal.org. To avoid confusion the maintainer of that issue has disabled commenting and opening a child issue for composer friendly patches for this issue. This is a better reference point for future patches until the parent issue becomes unblocked.