### PR TITLE
Support digest and event in containing query

### DIFF
--- a/src/modules/jcms_rest/src/Plugin/rest/resource/CollectionListRestResource.php
+++ b/src/modules/jcms_rest/src/Plugin/rest/resource/CollectionListRestResource.php
@@ -38,7 +38,7 @@ class CollectionListRestResource extends AbstractRestResourceBase {
     }
 
     $this->filterSubjects($base_query);
-    $this->filterContaining($base_query);
+    $this->filterContaining($base_query, 'field_collection_content');
 
     $count_query = clone $base_query;
     $items_query = clone $base_query;

--- a/src/modules/jcms_rest/src/Plugin/rest/resource/CollectionListRestResource.php
+++ b/src/modules/jcms_rest/src/Plugin/rest/resource/CollectionListRestResource.php
@@ -3,7 +3,6 @@
 namespace Drupal\jcms_rest\Plugin\rest\resource;
 
 use Drupal\Core\Entity\EntityInterface;
-use Drupal\jcms_rest\Exception\JCMSBadRequestHttpException;
 use Drupal\jcms_rest\Response\JCMSRestResponse;
 use Drupal\node\Entity\Node;
 use Drupal\node\NodeInterface;
@@ -39,37 +38,7 @@ class CollectionListRestResource extends AbstractRestResourceBase {
     }
 
     $this->filterSubjects($base_query);
-
-    $containing = \Drupal::request()->query->get('containing', []);
-    if (!empty($containing)) {
-      $orCondition = $base_query->orConditionGroup();
-
-      foreach ($containing as $item) {
-        preg_match('~^(article|blog-article|interview)/([a-z0-9-]+)$~', $item, $matches);
-
-        if (empty($matches[1]) || empty($matches[2])) {
-          throw new JCMSBadRequestHttpException(t('Invalid containing parameter'));
-        }
-
-        $andCondition = $base_query->andConditionGroup()
-          ->condition('field_collection_content.entity.type', str_replace('-', '_', $matches[1]));
-
-        if (!$this->viewUnpublished()) {
-          $andCondition->condition('field_collection_content.entity.status', NodeInterface::PUBLISHED);
-        }
-
-        if ('article' === $matches[1]) {
-          $andCondition = $andCondition->condition('field_collection_content.entity.title', $matches[2], '=');
-        }
-        else {
-          $andCondition = $andCondition->condition('field_collection_content.entity.uuid', $matches[2], 'ENDS_WITH');
-        }
-
-        $orCondition = $orCondition->condition($andCondition);
-      }
-
-      $base_query = $base_query->condition($orCondition);
-    }
+    $this->filterContaining($base_query);
 
     $count_query = clone $base_query;
     $items_query = clone $base_query;

--- a/src/modules/jcms_rest/src/Plugin/rest/resource/PodcastEpisodeListRestResource.php
+++ b/src/modules/jcms_rest/src/Plugin/rest/resource/PodcastEpisodeListRestResource.php
@@ -3,7 +3,6 @@
 namespace Drupal\jcms_rest\Plugin\rest\resource;
 
 use Drupal\Core\Entity\EntityInterface;
-use Drupal\jcms_rest\Exception\JCMSBadRequestHttpException;
 use Drupal\jcms_rest\Response\JCMSRestResponse;
 use Drupal\node\Entity\Node;
 use Drupal\node\NodeInterface;
@@ -39,33 +38,7 @@ class PodcastEpisodeListRestResource extends AbstractRestResourceBase {
     }
 
     $this->filterSubjects($base_query);
-
-    $containing = \Drupal::request()->query->get('containing', []);
-    if (!empty($containing)) {
-      $orCondition = $base_query->orConditionGroup();
-
-      foreach ($containing as $item) {
-        preg_match('~^(article|collection)/([a-z0-9-]+)$~', $item, $matches);
-
-        if (empty($matches[1]) || empty($matches[2])) {
-          throw new JCMSBadRequestHttpException(t('Invalid containing parameter'));
-        }
-
-        $andCondition = $base_query->andConditionGroup()
-          ->condition('field_episode_chapter.entity.field_related_content.entity.type', str_replace('-', '_', $matches[1]));
-
-        if ('article' === $matches[1]) {
-          $andCondition = $andCondition->condition('field_episode_chapter.entity.field_related_content.entity.title', $matches[2], '=');
-        }
-        else {
-          $andCondition = $andCondition->condition('field_episode_chapter.entity.field_related_content.entity.uuid', $matches[2], 'ENDS_WITH');
-        }
-
-        $orCondition = $orCondition->condition($andCondition);
-      }
-
-      $base_query = $base_query->condition($orCondition);
-    }
+    $this->filterContaining($base_query, 'field_episode_chapter.entity.field_related_content', ['article', 'collection']);
 
     $count_query = clone $base_query;
     $items_query = clone $base_query;

--- a/src/modules/jcms_rest/tests/src/Functional/ValidQueryEndpointTest.php
+++ b/src/modules/jcms_rest/tests/src/Functional/ValidQueryEndpointTest.php
@@ -1,0 +1,137 @@
+<?php
+
+namespace Drupal\Tests\jcms_rest\Functional;
+
+use GuzzleHttp\Psr7\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Test correct response for requests with query parameters on API endpoints.
+ *
+ * @package Drupal\Tests\jcms_rest\Functional
+ */
+class ValidQueryEndpointTest extends FixtureBasedTestCase {
+
+  /**
+   * Provider for valid query parameters.
+   */
+  public function validQueryEndpointProvider() : array {
+    return [
+      'containing - collections' => [
+        '/collections?containing[]=article/1&containing[]=blog-article/2&containing[]=digest/3&containing[]=event/4&containing[]=interview/5',
+        200,
+      ],
+      'containing - collections - unsupported' => [
+        '/collections?containing[]=article/1&containing[]=collection/2',
+        400,
+        'Invalid containing parameter',
+      ],
+      'containing - podcast-episodes' => [
+        '/podcast-episodes?containing[]=article/1&containing[]=collection/2',
+        200,
+      ],
+      'containing - podcast-episodes - unsupported' => [
+        '/podcast-episodes?containing[]=article/1&containing[]=blog-article/2',
+        400,
+        'Invalid containing parameter',
+      ],
+      'order - desc' => [
+        '/collections?order=desc',
+        200,
+      ],
+      'order - asc' => [
+        '/collections?order=asc',
+        200,
+      ],
+      'order - unsupported' => [
+        '/collections?order=unsupported',
+        400,
+        'Invalid order option',
+      ],
+      'start-date' => [
+        '/events?start-date=2020-01-01',
+        200,
+      ],
+      'start-date - unsupported' => [
+        '/covers?start-date=unsupported',
+        400,
+        'Invalid start date',
+      ],
+      'end-date' => [
+        '/events?end-date=2020-01-02',
+        200,
+      ],
+      'end-date - unsupported' => [
+        '/covers?end-date=2020/1/1',
+        400,
+        'Invalid end date',
+      ],
+      'start-date before end-date' => [
+        '/events?start-date=2020-01-01&end-date=2020-01-02',
+        200,
+      ],
+      'start-date same as end-date' => [
+        '/covers?start-date=2020-01-01&end-date=2020-01-01',
+        200,
+      ],
+      'start-date after end-date' => [
+        '/covers?start-date=2020-01-02&end-date=2020-01-01',
+        400,
+        'End date must be on or after start date',
+      ],
+      'use-date - published' => [
+        '/covers?use-date=published',
+        200,
+      ],
+      'use-date - default' => [
+        '/covers?use-date=default',
+        200,
+      ],
+      'use-date - unsupported' => [
+        '/covers?use-date=unsupported',
+        400,
+        'Invalid use date',
+      ],
+      'sort - date' => [
+        '/events?sort=date',
+        200,
+      ],
+      'sort - page-views' => [
+        '/events?sort=page-views',
+        200,
+      ],
+      'sort - unsupported' => [
+        '/events?sort=unsupported',
+        400,
+        'Invalid sort option',
+      ],
+      'show - all' => [
+        '/events?show=all',
+        200,
+      ],
+      'show - unsupported' => [
+        '/events?show=unsupported',
+        400,
+        'Invalid show option',
+      ],
+    ];
+  }
+
+  /**
+   * Test valid query parameters requests.
+   *
+   * @test
+   * @dataProvider validQueryEndpointProvider
+   */
+  public function validQueryEndpoint(string $url, int $expected_status, string $message = NULL) {
+    $request = new Request('GET', $url);
+    $response = $this->client->send($request);
+    $this->assertEquals($expected_status, $response->getStatusCode());
+    if (Response::HTTP_BAD_REQUEST === $expected_status) {
+      $this->assertEquals('application/problem+json', $response->getHeaderLine('Content-Type'));
+      $data = \GuzzleHttp\json_decode((string) $response->getBody());
+      $this->assertEquals($message, $data->message);
+    }
+  }
+
+}


### PR DESCRIPTION
The `containing[]` query on `/collections` does not `digest` and `event`. 

I have pulled down the latest content and there is currently no `digest` or `event` which has been added to a collection but this ensures that the query would work if there was.