### PR TITLE
Update inline_entity_form to 8.x-1.0-rc7

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -3965,29 +3965,29 @@
         },
         {
             "name": "drupal/inline_entity_form",
-            "version": "1.0.0-rc3",
+            "version": "1.0.0-rc7",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/inline_entity_form.git",
-                "reference": "8.x-1.0-rc3"
+                "reference": "8.x-1.0-rc7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/inline_entity_form-8.x-1.0-rc3.zip",
-                "reference": "8.x-1.0-rc3",
-                "shasum": "f0508db2d64133e2df0af24e7fc914cbb5492211"
+                "url": "https://ftp.drupal.org/files/projects/inline_entity_form-8.x-1.0-rc7.zip",
+                "reference": "8.x-1.0-rc7",
+                "shasum": "a11e59a8f3632728165170e9337cec9bc8eab870"
             },
             "require": {
                 "drupal/core": "^8.7.7 || ^9"
             },
             "require-dev": {
-                "drupal/entity_reference_revisions": "*"
+                "drupal/entity_reference_revisions": "^1.0"
             },
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "8.x-1.0-rc3",
-                    "datestamp": "1581640483",
+                    "version": "8.x-1.0-rc7",
+                    "datestamp": "1595545223",
                     "security-coverage": {
                         "status": "not-covered",
                         "message": "RC releases are not covered by Drupal security advisories."


### PR DESCRIPTION
Among other things introduced by the update the inline_entity_form field names change which is causing an error in one of the end2end tests but the form works.

```
00:03:24  =================================== FAILURES ===================================
00:03:24  ________________ test_content_type_propagates_to_other_services ________________
00:03:24  [gw4] linux -- Python 3.6.9 /ext/srv/elife-spectrum/venv/bin/python3
00:03:24  @pytest.mark.journal_cms
00:03:24      @pytest.mark.search
00:03:24      def test_content_type_propagates_to_other_services():
00:03:24          journal_cms_session = input.JOURNAL_CMS.login()
00:03:24      
00:03:24          invented_word = input.invented_word()
00:03:24          title = 'Spectrum podcast episode: %s' % invented_word
00:03:24      
00:03:24  >       journal_cms_session.create_podcast_episode(title=title, image='./spectrum/fixtures/king_county.jpg', uri='https://cdn.elifesciences.org/podcast-episode.mp3', chapter_title='Chapter 1')
00:03:24  
00:03:24  spectrum/test_journal_cms.py:19: 
00:03:24  _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
00:03:24  spectrum/input.py:109: in create_podcast_episode
00:03:24      form.input({'field_episode_chapter[form][inline_entity_form][title][0][value]': chapter_title})
00:03:24  _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
00:03:24  
00:03:24  self = <mechanicalsoup.form.Form object at 0x7f2379bd6208>
00:03:24  data = {'field_episode_chapter[form][inline_entity_form][title][0][value]': 'Chapter 1'}
00:03:24  
00:03:24      def input(self, data):
00:03:24          for (name, value) in data.items():
00:03:24  >           self.form.find("input", {"name": name})["value"] = value
00:03:24  E           TypeError: 'NoneType' object does not support item assignment
00:03:24  
00:03:24  venv/lib/python3.6/site-packages/mechanicalsoup/form.py:8: TypeError
00:03:24  ===================== 1 failed, 25 passed in 93.01 seconds =====================
```

The field `field_episode_chapter[form][inline_entity_form][title][0][value]` changes to `field_episode_chapter[form][0][title][0][value]`.