### PR TITLE
Styling of bulleted lists is inconsistent in Job Advert posts

### DIFF
--- a/src/modules/jcms_admin/tests/src/Unit/HtmlJsonSerializerTest.php
+++ b/src/modules/jcms_admin/tests/src/Unit/HtmlJsonSerializerTest.php
@@ -1129,7 +1129,7 @@ class HtmlJsonSerializerTest extends UnitTestCase {
         [
           [
             'type' => 'paragraph',
-            'text' => 'Some Title',
+            'text' => 'Some Title:',
           ],
           [
             'type' => 'list',
@@ -1137,11 +1137,13 @@ class HtmlJsonSerializerTest extends UnitTestCase {
             'items' => [
               'Item 1',
               'Item 2',
+              'Item 3',
+              'Item 4',
             ],
           ],
           [
             'type' => 'paragraph',
-            'text' => 'Another Title',
+            'text' => 'Another Title:',
           ],
           [
             'type' => 'list',
@@ -1149,19 +1151,25 @@ class HtmlJsonSerializerTest extends UnitTestCase {
             'items' => [
               'Item 1',
               'Item 2',
+              'Item 3',
+              'Item 4',
             ],
           ],
         ],
         $this->lines([
-          '<p>Some Title</p>',
+          '<p>Some Title:</p>',
           '<ul>',
           '<li>Item 1</li>',
           '<li>Item 2</li>',
+          '<li>Item 3</li>',
+          '<li>Item 4</li>',
           '</ul>',
-          '<p>Another Title</p>',
+          '<p>Another Title:</p>',
           '<ul>',
           '<li>Item 1</li>',
-          '<li>Item 1</li>',
+          '<li>Item 2</li>',
+          '<li>Item 3</li>',
+          '<li>Item 4</li>',
           '</ul>'
         ]),
       ],

--- a/src/modules/jcms_admin/tests/src/Unit/HtmlJsonSerializerTest.php
+++ b/src/modules/jcms_admin/tests/src/Unit/HtmlJsonSerializerTest.php
@@ -1125,6 +1125,46 @@ class HtmlJsonSerializerTest extends UnitTestCase {
         [],
         '<p><placeholder>Type something here ...</placeholder></p>',
       ],
+      'bulleted lists' => [
+        [
+          [
+            'type' => 'paragraph',
+            'text' => 'Some Title',
+          ],
+          [
+            'type' => 'list',
+            'prefix' => 'bullet',
+            'items' => [
+              'Item 1',
+              'Item 2',
+            ],
+          ],
+          [
+            'type' => 'paragraph',
+            'text' => 'Another Title',
+          ],
+          [
+            'type' => 'list',
+            'prefix' => 'bullet',
+            'items' => [
+              'Item 1',
+              'Item 2',
+            ],
+          ],
+        ],
+        $this->lines([
+          '<p>Some Title</p>',
+          '<ul>',
+          '<li>Item 1</li>',
+          '<li>Item 2</li>',
+          '</ul>',
+          '<p>Another Title</p>',
+          '<ul>',
+          '<li>Item 1</li>',
+          '<li>Item 1</li>',
+          '</ul>'
+        ]),
+      ],
     ];
   }
 


### PR DESCRIPTION
Fix the inconsistent styling of lists in job advert posts.

This fixes elifesciences/issues#6074