### PR TITLE
feat: update latest revision id method calls and modify cover slice arrays

### DIFF
--- a/src/modules/jcms_admin/jcms_admin.module
+++ b/src/modules/jcms_admin/jcms_admin.module
@@ -503,7 +503,7 @@ function jcms_admin_entity_subqueue_presave(EntityInterface $entity) {
     foreach ($items as $item) {
       $latest = $node_storage->load($item['target_id']);
       if ($latest instanceof RevisionableInterface && !$latest->isLatestRevision() && $node_storage instanceof RevisionableStorageInterface) {
-        $latest_revision_id = $node_storage->getLatestRevisionId();
+        $latest_revision_id = $node_storage->getLatestRevisionId($item['target_id']);
         $latest = $node_storage->loadRevision($latest_revision_id);
       }
       $latest->set('moderation_state', 'published');

--- a/src/modules/jcms_admin/src/Commands/JcmsAdminCommands.php
+++ b/src/modules/jcms_admin/src/Commands/JcmsAdminCommands.php
@@ -178,7 +178,7 @@ class JcmsAdminCommands extends DrushCommands {
       ->exists('field_image')
       ->execute();
     shuffle($covers);
-    $covers = array_slice($covers, 0, 3);
+    $covers = array_slice($covers, 0, 4);
     array_walk($covers, function (&$cover) {
       $node = Node::load($cover);
       $node->set('moderation_state', 'published');
@@ -193,6 +193,38 @@ class JcmsAdminCommands extends DrushCommands {
     $subqueue->save();
 
     $this->output()->writeln(dt('Covers list populated with random covers'));
+  }
+
+  /**
+   * Populate covers entityqueue with random covers.
+   *
+   * @validate-module-enabled jcms_admin
+   *
+   * @command jcms:covers-preview-random
+   * @aliases jcms-covers-preview-random
+   */
+  public function coversPreviewRandom() {
+    $covers = \Drupal::entityQuery('node')
+      ->accessCheck(TRUE)
+      ->condition('type', 'cover')
+      ->exists('field_image')
+      ->execute();
+    shuffle($covers);
+    $covers = array_slice($covers, 0, 5);
+    array_walk($covers, function (&$cover) {
+      $node = Node::load($cover);
+      $node->set('moderation_state', 'published');
+      $node->save();
+      $cover = [
+        'target_id' => $cover,
+      ];
+    });
+
+    $subqueue = EntitySubqueue::load('covers_preview');
+    $subqueue->set('items', $covers);
+    $subqueue->save();
+
+    $this->output()->writeln(dt('Covers Preview list populated with random covers'));
   }
 
 }

--- a/src/modules/jcms_admin/src/Plugin/Field/FieldWidget/InlineEntityFormComplex.php
+++ b/src/modules/jcms_admin/src/Plugin/Field/FieldWidget/InlineEntityFormComplex.php
@@ -40,7 +40,7 @@ class InlineEntityFormComplex extends IefInlineEntityFormComplex {
         if ($entity instanceof RevisionableInterface && !$entity->isLatestRevision($entity)) {
           /** @var \Drupal\Core\Entity\RevisionableStorageInterface $entity_storage */
           $entity_storage = \Drupal::entityTypeManager()->getStorage($entity->getEntityTypeId());
-          $latest_revision_id = $entity_storage->getLatestRevisionId();
+          $latest_revision_id = $entity_storage->getLatestRevisionId($entity->id());
           $latest = $entity_storage->loadRevision($latest_revision_id);
           $row['#label'] = $this->inlineFormHandler->getEntityLabel($latest) . ' *';
         }

--- a/src/modules/jcms_rest/src/Plugin/rest/resource/CoverCurrentListRestResource.php
+++ b/src/modules/jcms_rest/src/Plugin/rest/resource/CoverCurrentListRestResource.php
@@ -88,7 +88,7 @@ class CoverCurrentListRestResource extends AbstractRestResourceBase {
         /** @var \Drupal\Core\Entity\RevisionableStorageInterface $entity_storage */
         $entity_storage = \Drupal::entityTypeManager()
           ->getStorage($item_node->getEntityTypeId());
-        $latest_revision_id = $entity_storage->getLatestRevisionId();
+        $latest_revision_id = $entity_storage->getLatestRevisionId($item_node->id());
         $item_node = $entity_storage->loadRevision($latest_revision_id);
       }
       if ($item_node->get('field_image')->count()) {


### PR DESCRIPTION
Update several files in jcms_admin and jcms_rest modules. In jcms_admin.module, JcmsAdminCommands.php and InlineEntityFormComplex.php, modify the calls to getLatestRevisionId method by passing the target id. In JcmsAdminCommands.php change the slicing of the covers array to take the first four elements instead of three. Add a new function to populate the covers entityqueue with random covers. In CoverCurrentListRestResource.php of jcms_rest module, alter the getLatestRevisionId method call by passing the item node's id.