### PR TITLE
feat: Update REST resources for collection items

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -328,7 +328,7 @@
     "drupal/services": "^4.0@beta",
     "drupal/transliterate_filenames": "^2.0",
     "drush/drush": "^10",
-    "elife/api": "*",
+    "elife/api": "^2.24",
     "elife/api-sdk": "1.0.x-dev",
     "elife/api-validator": "^1.0@dev",
     "elife/bus-sdk": "dev-master",

--- a/composer.json
+++ b/composer.json
@@ -328,7 +328,7 @@
     "drupal/services": "^4.0@beta",
     "drupal/transliterate_filenames": "^2.0",
     "drush/drush": "^10",
-    "elife/api": "^2.21",
+    "elife/api": "*",
     "elife/api-sdk": "1.0.x-dev",
     "elife/api-validator": "^1.0@dev",
     "elife/bus-sdk": "dev-master",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "adc20f347a957ebb324b90b92294326b",
+    "content-hash": "850f791d09b3b025687636101b121260",
     "packages": [
         {
             "name": "alchemy/zippy",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d24ceb354d2528aeb865a039934fab88",
+    "content-hash": "adc20f347a957ebb324b90b92294326b",
     "packages": [
         {
             "name": "alchemy/zippy",
@@ -5860,16 +5860,16 @@
         },
         {
             "name": "elife/api",
-            "version": "2.21.0",
+            "version": "2.24.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/elifesciences/api-raml.git",
-                "reference": "dc41f529a0408242a97dc79bec4035e13a9ceaa5"
+                "reference": "a7498520f44430df041a4a1877431692a956fd34"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/elifesciences/api-raml/zipball/dc41f529a0408242a97dc79bec4035e13a9ceaa5",
-                "reference": "dc41f529a0408242a97dc79bec4035e13a9ceaa5",
+                "url": "https://api.github.com/repos/elifesciences/api-raml/zipball/a7498520f44430df041a4a1877431692a956fd34",
+                "reference": "a7498520f44430df041a4a1877431692a956fd34",
                 "shasum": ""
             },
             "conflict": {
@@ -5883,9 +5883,9 @@
             "description": "eLife Sciences API specification",
             "support": {
                 "issues": "https://github.com/elifesciences/api-raml/issues",
-                "source": "https://github.com/elifesciences/api-raml/tree/2.21.0"
+                "source": "https://github.com/elifesciences/api-raml/tree/2.24.0"
             },
-            "time": "2023-05-24T08:11:39+00:00"
+            "time": "2023-10-09T12:20:20+00:00"
         },
         {
             "name": "elife/api-client",

--- a/src/modules/jcms_rest/src/Plugin/rest/resource/AbstractRestResourceBase.php
+++ b/src/modules/jcms_rest/src/Plugin/rest/resource/AbstractRestResourceBase.php
@@ -603,7 +603,7 @@ abstract class AbstractRestResourceBase extends ResourceBase {
               break;
 
             case 'article':
-              if ($snippet = $this->getArticleSnippet($content)) {
+              if ($snippet = $this->getArticleSnippet($content, TRUE)) {
                 $item[$k][] = $snippet;
               }
               break;

--- a/src/modules/jcms_rest/src/Plugin/rest/resource/CollectionItemRestResource.php
+++ b/src/modules/jcms_rest/src/Plugin/rest/resource/CollectionItemRestResource.php
@@ -28,7 +28,14 @@ class CollectionItemRestResource extends AbstractRestResourceBase {
    *
    * @var int
    */
-  protected $latestVersion = 2;
+  protected $latestVersion = 3;
+
+  /**
+   * Minimum version.
+   *
+   * @var int
+   */
+  protected $minVersion = 2;
 
   /**
    * Responds to GET requests.
@@ -96,23 +103,15 @@ class CollectionItemRestResource extends AbstractRestResourceBase {
 
     $item += $this->extendedCollectionItem($node);
 
-    foreach (['field_collection_content', 'field_collection_related_content'] as $field) {
-      foreach ($node->get($field)->referencedEntities() as $content) {
-        /** @var \Drupal\node\Entity\Node $content */
-        if ($content->isPublished() || $this->viewUnpublished()) {
-          switch ($content->getType()) {
-            case 'event':
-              if ($this->acceptVersion < 2) {
-                throw new JCMSNotAcceptableHttpException('This collection requires version 2+.');
+    foreach (['content', 'relatedContent'] as $field) {
+      if (isset($item[$field]) && count($item[$field]) > 0) {
+        foreach ($item[$field] as $content) {
+          switch ($content['type']) {
+            case 'reviewed-preprint':
+              if ($this->acceptVersion < 3) {
+                throw new JCMSNotAcceptableHttpException('This collection requires version 3+.');
               }
               break;
-
-            case 'digest':
-              if ($snippet = $this->getDigestSnippet($content)) {
-                if ($this->acceptVersion < 2) {
-                  throw new JCMSNotAcceptableHttpException('This collection requires version 2+.');
-                }
-              }
 
             default:
           }

--- a/src/modules/jcms_rest/tests/src/Functional/UnrecognisedAcceptHeaderTest.php
+++ b/src/modules/jcms_rest/tests/src/Functional/UnrecognisedAcceptHeaderTest.php
@@ -85,7 +85,7 @@ class UnrecognisedAcceptHeaderTest extends FixtureBasedTestCase {
         '/collections',
         [
           'application/vnd.elife.collection-list+json;version=1',
-          'application/vnd.elife.collection+json;version=2',
+          'application/vnd.elife.collection+json;version=3',
         ],
         'id',
       ],

--- a/src/modules/jcms_rest/tests/src/Functional/UnrecognisedAcceptHeaderTest.php
+++ b/src/modules/jcms_rest/tests/src/Functional/UnrecognisedAcceptHeaderTest.php
@@ -137,7 +137,7 @@ class UnrecognisedAcceptHeaderTest extends FixtureBasedTestCase {
         '/promotional-collections',
         [
           'application/vnd.elife.promotional-collection-list+json;version=1',
-          'application/vnd.elife.promotional-collection+json;version=1',
+          'application/vnd.elife.promotional-collection+json;version=2',
         ],
         'id',
       ],

--- a/src/modules/jcms_rest/tests/src/Functional/WrongVersionEndpointTest.php
+++ b/src/modules/jcms_rest/tests/src/Functional/WrongVersionEndpointTest.php
@@ -155,7 +155,8 @@ class WrongVersionEndpointTest extends FixtureBasedTestCase {
         '/collections',
         'id',
         [
-          'application/vnd.elife.collection+json; version=3',
+          'application/vnd.elife.collection+json; version=1',
+          'application/vnd.elife.collection+json; version=4',
         ],
       ],
       [
@@ -183,7 +184,7 @@ class WrongVersionEndpointTest extends FixtureBasedTestCase {
         '/promotional-collections',
         'id',
         [
-          'application/vnd.elife.promotional-collection+json; version=2',
+          'application/vnd.elife.promotional-collection+json; version=3',
         ],
       ],
       [


### PR DESCRIPTION
The REST resources for collection items have been updated to include changes in the 'AbstractRestResourceBase.php', 'CollectionItemRestResource.php' and 'PromotionalCollectionItemRestResource.php' files. The 'getArticleSnippet' method now accepts a second argument. The 'latestVersion' and 'minVersion' properties were also updated in the 'CollectionItemRestResource.php' file. Additional logic for handling 'reviewed-preprint' type content was also added.