### PR TITLE
feat: Add start-date filter to reviewed preprints fetch

### DIFF
--- a/src/modules/jcms_article/src/FetchReviewedPreprint.php
+++ b/src/modules/jcms_article/src/FetchReviewedPreprint.php
@@ -103,7 +103,7 @@ class FetchReviewedPreprint {
   /**
    * Gets every reviewed preprints.
    */
-  public function getAllReviewedPreprints() : array {
+  public function getAllReviewedPreprints($start_date = NULL) : array {
     $reviewed_preprints = [];
     $endpoint = Settings::get('jcms_all_reviewed_preprints_endpoint');
     if ($endpoint) {
@@ -123,10 +123,11 @@ class FetchReviewedPreprint {
       }
       while (!$stop) {
         $response = $this->client->get($endpoint, $options + [
-          'query' => [
+          'query' => array_filter([
             'per-page' => $per_page,
             'page' => $page,
-          ],
+            'start-date' => $start_date,
+          ]),
         ]);
         if ($response instanceof ResponseInterface) {
           $json = json_decode((string) $response->getBody(), TRUE);

--- a/src/modules/jcms_notifications/src/Commands/JcmsNotificationsCommands.php
+++ b/src/modules/jcms_notifications/src/Commands/JcmsNotificationsCommands.php
@@ -314,8 +314,12 @@ class JcmsNotificationsCommands extends DrushCommands {
    *   Limit on the number of items to process in each import.
    * @option skip-updates
    *   Do not attempt to update reviewed preprints that exist already.
+   * @option start-date
+   *   Apply start-date filter.
    * @usage drush reviewed-preprint-import-all
    *   Import all reviewed preprints and return a message when finished.
+   * @usage drush reviewed-preprint-import-all --start-date=today
+   *   Import all reviewed preprints updated after start-date and return a message when finished.
    * @usage drush reviewed-preprint-import-all --limit=500
    *   Import first 500 reviewed preprints and return a message when finished.
    * @usage drush reviewed-preprint-import-all --skip-updates
@@ -338,7 +342,8 @@ class JcmsNotificationsCommands extends DrushCommands {
     if (!empty($limit)) {
       $fetch_service->setLimit($limit);
     }
-    $reviewedPreprints = $fetch_service->getAllReviewedPreprints();
+    $start_date = $options['start-date'] ? date('Y-m-d', strtotime(['start-date'])) : NULL;
+    $reviewedPreprints = $fetch_service->getAllReviewedPreprints($start_date);
     $this->output()->writeln(dt('Received !count reviewed preprint IDs to process.', ['!count' => count($reviewedPreprints)]));
     if ($reviewedPreprints) {
       $time_start = microtime(TRUE);

--- a/src/modules/jcms_notifications/src/Commands/JcmsNotificationsCommands.php
+++ b/src/modules/jcms_notifications/src/Commands/JcmsNotificationsCommands.php
@@ -319,7 +319,8 @@ class JcmsNotificationsCommands extends DrushCommands {
    * @usage drush reviewed-preprint-import-all
    *   Import all reviewed preprints and return a message when finished.
    * @usage drush reviewed-preprint-import-all --start-date=today
-   *   Import all reviewed preprints updated after start-date and return a message when finished.
+   *   Import all reviewed preprints updated after start-date and return a
+   * message when finished.
    * @usage drush reviewed-preprint-import-all --limit=500
    *   Import first 500 reviewed preprints and return a message when finished.
    * @usage drush reviewed-preprint-import-all --skip-updates


### PR DESCRIPTION
Update the `getAllReviewedPreprints` function to accept an optional start-date. This allows fetching of reviewed preprints from a given date. Also, update `JcmsNotificationsCommands` to support this new filter, providing usage examples for new feature.