### PR TITLE
feat: Update README.md with additional local setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,16 @@ The setup of goaws has been temporarily disabled. Most development is unimpacted
 First you need to install DDev, installation instruction for most platforms available here: `https://ddev.readthedocs.io/en/latest/users/install/ddev-installation/`
 
 ```bash
+ddev composer install
 ddev start
 ddev drush si minimal --existing-config -y
 ```
 
 Visit http://journal-cms.ddev.site:8080.
+
+If you want to completely replay the set up of this project locally then you can run the following commands:
+
+```
+ddev stop --remove-data
+ddev composer run-script clean-up
+```


### PR DESCRIPTION
This commit adds extra steps to the README.md file to guide users on how to completely replay the setup of the project locally. The new instructions include running 'ddev stop --remove-data' and 'ddev composer run-script clean-up'.