### PR TITLE
feat: update redis version and add global cache volume

### DIFF
--- a/.ddev/addon-metadata/redis/manifest.yaml
+++ b/.ddev/addon-metadata/redis/manifest.yaml
@@ -1,7 +1,7 @@
 name: redis
 repository: ddev/ddev-redis
-version: v1.2.0
-install_date: "2024-02-13T21:13:38Z"
+version: v1.2.1
+install_date: "2024-03-19T23:09:49Z"
 project_files:
     - docker-compose.redis.yaml
     - redis/scripts/settings.ddev.redis.php

--- a/.ddev/docker-compose.redis.yaml
+++ b/.ddev/docker-compose.redis.yaml
@@ -9,6 +9,7 @@ services:
       com.ddev.approot: $DDEV_APPROOT
     volumes:
     - ".:/mnt/ddev_config"
+    - "ddev-global-cache:/mnt/ddev-global-cache"
     - "./redis:/usr/local/etc/redis"
     - "redis:/data"
     command: ["redis-server", "/usr/local/etc/redis/redis.conf"]


### PR DESCRIPTION
Updated the version of redis in the manifest.yaml from v1.2.0 to v1.2.1 and the install date. Additionally, added a global cache volume in docker-compose.redis.yaml.