### PR TITLE
feat: update league/html-to-markdown to 4.10.0

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -7635,16 +7635,16 @@
         },
         {
             "name": "league/html-to-markdown",
-            "version": "4.7.0",
+            "version": "4.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/html-to-markdown.git",
-                "reference": "76c076483cef89860d32a3fd25312f5a42848a8c"
+                "reference": "0868ae7a552e809e5cd8f93ba022071640408e88"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/html-to-markdown/zipball/76c076483cef89860d32a3fd25312f5a42848a8c",
-                "reference": "76c076483cef89860d32a3fd25312f5a42848a8c",
+                "url": "https://api.github.com/repos/thephpleague/html-to-markdown/zipball/0868ae7a552e809e5cd8f93ba022071640408e88",
+                "reference": "0868ae7a552e809e5cd8f93ba022071640408e88",
                 "shasum": ""
             },
             "require": {
@@ -7654,7 +7654,7 @@
             },
             "require-dev": {
                 "mikehaertl/php-shellcommand": "~1.1.0",
-                "phpunit/phpunit": "4.*",
+                "phpunit/phpunit": "^4.8|^5.7",
                 "scrutinizer/ocular": "~1.1"
             },
             "bin": [
@@ -7663,7 +7663,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.8-dev"
+                    "dev-master": "4.10-dev"
                 }
             },
             "autoload": {
@@ -7679,7 +7679,7 @@
                 {
                     "name": "Colin O'Dell",
                     "email": "colinodell@gmail.com",
-                    "homepage": "http://www.colinodell.com",
+                    "homepage": "https://www.colinodell.com",
                     "role": "Lead Developer"
                 },
                 {
@@ -7697,9 +7697,27 @@
             ],
             "support": {
                 "issues": "https://github.com/thephpleague/html-to-markdown/issues",
-                "source": "https://github.com/thephpleague/html-to-markdown/tree/master"
+                "source": "https://github.com/thephpleague/html-to-markdown/tree/4.10.0"
             },
-            "time": "2018-05-19T23:47:12+00:00"
+            "funding": [
+                {
+                    "url": "https://www.colinodell.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.paypal.me/colinpodell/10.00",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/colinodell",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/colinodell",
+                    "type": "patreon"
+                }
+            ],
+            "time": "2020-07-01T00:34:03+00:00"
         },
         {
             "name": "longwave/laminas-diactoros",
@@ -16334,6 +16352,7 @@
         "drupal/entity_reference_revisions": 20,
         "drupal/entity_reference_unpublished": 15,
         "drupal/field_validation": 10,
+        "drupal/gin": 5,
         "drupal/monolog": 20,
         "drupal/restui": 20,
         "drupal/services": 10,

--- a/src/modules/jcms_admin/src/HtmlMarkdownSerializer.php
+++ b/src/modules/jcms_admin/src/HtmlMarkdownSerializer.php
@@ -151,7 +151,7 @@ final class HtmlMarkdownSerializer implements NormalizerInterface {
     $bc = $this->bracketChar;
     $output = preg_replace_callback('~' . $bc . 'preserve([^' . $bc . ']*)preserve' . $bc . '~s', function ($matches) {
       return base64_decode($matches[1]);
-    }, preg_replace('~(preserve' . $bc . ')\s*([^\n])~', '$1' . PHP_EOL . PHP_EOL . '$2', $html));
+    }, preg_replace('~(preserve' . $bc . ')\s*([^\n])~', '$1' . PHP_EOL . PHP_EOL . '$2', htmlspecialchars_decode($html)));
     return preg_replace('/\n{2,}/', PHP_EOL . PHP_EOL, $output);
   }
 


### PR DESCRIPTION
This commit updates the league/html-to-markdown library version to 4.10.0 in composer.lock. The composer.lock file also indicates that PHPUnit has been updated to support versions 4.8 and 5.7. In addition, there are changes to the support and funding urls.

The "drupal/gin" package was also added to the list of packages in composer.lock.

Finally, in HtmlMarkdownSerializer.php, an adjustment has been made to decode HTML special characters before processing preservation markup.